### PR TITLE
Replace std::runtime_error and std::system_error with CryMP_Error

### DIFF
--- a/Code/CryMP/Client/MapDownloader.cpp
+++ b/Code/CryMP/Client/MapDownloader.cpp
@@ -165,7 +165,7 @@ bool MapDownloader::CheckMapVersion(const std::string_view & mapName, const std:
 
 		return file.IsOpen() && file.Read() == mapVersion;
 	}
-	catch (const std::runtime_error& error)
+	catch (const CryMP_Error& error)
 	{
 		CryLogAlways("$4[CryMP] [MapDownloader] Failed to read map version: %s", error.what());
 		return false;
@@ -183,7 +183,7 @@ void MapDownloader::StoreMapVersion(const std::string_view & mapName, const std:
 		file.Resize(0);
 		file.Write(mapVersion);
 	}
-	catch (const std::runtime_error& error)
+	catch (const CryMP_Error& error)
 	{
 		CryLogAlways("$4[CryMP] [MapDownloader] Failed to store map version: %s", error.what());
 	}

--- a/Code/Launcher/Main.cpp
+++ b/Code/Launcher/Main.cpp
@@ -1,6 +1,8 @@
-#include <stdexcept>
-#include <string>
+#ifdef CRYMP_CONSOLE_APP
+#include <cstdio>
+#endif
 
+#include "Library/StringTools.h"  // CryMP_Error
 #include "Library/WinAPI.h"
 
 #include "Launcher.h"
@@ -18,19 +20,6 @@ extern "C" __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static std::string RuntimeErrorToString(const std::runtime_error& error)
-{
-	std::string message = error.what();
-	std::string::size_type pos = 0;
-
-	while ((pos = message.find(": ", pos)) != std::string::npos)
-	{
-		message.replace(pos, 2, "\n");
-	}
-
-	return message;
-}
-
 #ifdef CRYMP_CONSOLE_APP
 int main()
 #else
@@ -44,14 +33,13 @@ int __stdcall WinMain(void*, void*, char*, int)
 	{
 		launcher.Run();
 	}
-	catch (const std::runtime_error& error)
+	catch (const CryMP_Error& error)
 	{
-		WinAPI::ErrorBox(RuntimeErrorToString(error).c_str());
-		return 1;
-	}
-	catch (const std::exception& ex)
-	{
-		WinAPI::ErrorBox(ex.what());
+#ifdef CRYMP_CONSOLE_APP
+		std::fprintf(stderr, "%s\n", error.what());
+#else
+		WinAPI::ErrorBox(error.what());
+#endif
 		return 1;
 	}
 

--- a/Code/Library/StringTools.h
+++ b/Code/Library/StringTools.h
@@ -2,11 +2,36 @@
 
 #include <cstdarg>
 #include <cstddef>
-#include <stdexcept>
+#include <exception>
 #include <string>
 #include <string_view>
-#include <system_error>
+#include <system_error>  // std::error_code
 #include <type_traits>
+
+class CryMP_Error : public std::exception
+{
+	std::string m_what;
+	std::string m_message;
+	std::error_code m_code;
+
+public:
+	explicit CryMP_Error(const std::string& message, std::error_code code = {});
+
+	const char* what() const noexcept override
+	{
+		return m_what.c_str();
+	}
+
+	const std::string& message() const noexcept
+	{
+		return m_message;
+	}
+
+	const std::error_code& code() const noexcept
+	{
+		return m_code;
+	}
+};
 
 extern "C" __declspec(dllimport) int __stdcall MultiByteToWideChar(
 	unsigned int codepage,
@@ -348,12 +373,12 @@ namespace StringTools
 	std::size_t FormatTo(char* buffer, std::size_t bufferSize, const char* format, ...);
 	std::size_t FormatToV(char* buffer, std::size_t bufferSize, const char* format, va_list args);
 
-	std::runtime_error ErrorFormat(const char* format, ...);
-	std::runtime_error ErrorFormatV(const char* format, va_list args);
+	CryMP_Error ErrorFormat(const char* format, ...);
+	CryMP_Error ErrorFormatV(const char* format, va_list args);
 
-	std::system_error SysErrorFormat(const char* format, ...);
-	std::system_error SysErrorFormatV(const char* format, va_list args);
+	CryMP_Error SysErrorFormat(const char* format, ...);
+	CryMP_Error SysErrorFormatV(const char* format, va_list args);
 
-	std::system_error SysErrorErrnoFormat(const char* format, ...);
-	std::system_error SysErrorErrnoFormatV(const char* format, va_list args);
+	CryMP_Error SysErrorErrnoFormat(const char* format, ...);
+	CryMP_Error SysErrorErrnoFormatV(const char* format, va_list args);
 }

--- a/Code/Library/WinAPI.h
+++ b/Code/Library/WinAPI.h
@@ -272,7 +272,7 @@ namespace WinAPI
 	using HTTPRequestReader = std::function<size_t(void*,size_t)>;  // buffer, buffer size, returns data length
 	using HTTPRequestCallback = std::function<void(uint64_t,const HTTPRequestReader&)>;  // content length, reader
 
-	// blocking, returns HTTP status code, throws std::system_error
+	// blocking, returns HTTP status code, throws CryMP_Error
 	int HTTPRequest(
 		const std::string_view & method,
 		const std::string_view & url,


### PR DESCRIPTION
The idea is that we want to catch and show only our own pretty errors. Everything else, such as mysterious exceptions coming from the STL (#300), should summon the crash logger to dump the context into the log file. This way we can trace the error.