### PR TITLE
Server PAK with the highest priority + Remove -oldgame and -oldss

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.h    linguist-language=C++
 *.h.in linguist-language=C++
+*.cdf  linguist-language=XML
 
 ThirdParty/** linguist-vendored=true

--- a/Code/CryGame/Game.h
+++ b/Code/CryGame/Game.h
@@ -107,8 +107,7 @@ static const int GLOBAL_SERVER_IP_KEY						=	1000;
 static const int GLOBAL_SERVER_PUBLIC_PORT_KEY	= 1001;
 static const int GLOBAL_SERVER_NAME_KEY					=	1002;
 
-class CGame :
-  public IGame, public IGameFrameworkListener
+class CGame final : public IGame, public IGameFrameworkListener
 {
 public:
   typedef bool (*BlockingConditionFunction)();

--- a/Code/CryMP/Client/Client.cpp
+++ b/Code/CryMP/Client/Client.cpp
@@ -16,7 +16,6 @@
 #include "CrySystem/RandomGenerator.h"
 #include "Launcher/Resources.h"
 #include "Library/StdFile.h"
-#include "Library/StringTools.h"
 #include "Library/Util.h"
 #include "Library/WinAPI.h"
 
@@ -277,29 +276,9 @@ void Client::Init(IGameFramework *pGameFramework)
 
 	m_pServerBrowser->QueryClientPublicAddress();
 
-	if (!WinAPI::CmdLine::HasArg("-oldgame"))
-	{
-		m_pGame = new CGame();
-	}
-	else
-	{
-		void* pCryGame = WinAPI::DLL::Load("CryGame.dll");
-		if (!pCryGame)
-		{
-			throw StringTools::SysErrorFormat("Failed to load the CryGame DLL!");
-		}
-
-		auto entry = static_cast<IGame::TEntryFunction>(WinAPI::DLL::GetSymbol(pCryGame, "CreateGame"));
-		if (!entry)
-		{
-			throw StringTools::ErrorFormat("The CryGame DLL is not valid!");
-		}
-
-		m_pGame = entry(pGameFramework);
-	}
-
 	// initialize the game
 	// mods are not supported
+	m_pGame = new CGame();
 	m_pGame->Init(pGameFramework);
 }
 

--- a/Code/CryMP/Client/Client.h
+++ b/Code/CryMP/Client/Client.h
@@ -12,6 +12,7 @@
 
 struct IConsoleCmdArgs;
 
+class CGame;
 class Executor;
 class FileDownloader;
 class FileCache;
@@ -30,7 +31,7 @@ class DrawTools;
 class Client : public IGameFrameworkListener, public ILevelSystemListener, public IEntitySystemSink
 {
 	IGameFramework *m_pGameFramework = nullptr;
-	IGame *m_pGame = nullptr;
+	CGame *m_pGame = nullptr;
 
 	std::unique_ptr<Executor> m_pExecutor;
 	std::unique_ptr<HTTPClient> m_pHTTPClient;

--- a/Code/CryMP/Client/ServerPAK.cpp
+++ b/Code/CryMP/Client/ServerPAK.cpp
@@ -1,5 +1,4 @@
 #include "CryCommon/CrySystem/ISystem.h"
-#include "CryCommon/CrySystem/ICryPak.h"
 #include "CryCommon/CryEntitySystem/IEntitySystem.h"
 #include "CryCommon/CryScriptSystem/IScriptSystem.h"
 #include "CryCommon/CryNetwork/INetwork.h"
@@ -9,6 +8,7 @@
 #include "CryGame/Game.h"
 #include "CryGame/Items/ItemSharedParams.h"
 #include "CryGame/Items/Weapons/WeaponSystem.h"
+#include "CrySystem/CryPak.h"
 
 #include "ServerPAK.h"
 
@@ -24,7 +24,7 @@ bool ServerPAK::Load(const std::string & path)
 {
 	Unload();
 
-	const bool opened = gEnv->pCryPak->OpenPack("game\\", path.c_str());
+	const bool opened = CryPak::GetInstance().LoadServerPak(path);
 	if (opened)
 	{
 		CryLogAlways("$3[CryMP] [ServerPAK] Loaded $6%s", path.c_str());
@@ -48,7 +48,7 @@ bool ServerPAK::Unload()
 		return false;
 	}
 
-	const bool closed = gEnv->pCryPak->ClosePack(m_path.c_str());
+	const bool closed = CryPak::GetInstance().UnloadServerPak(m_path);
 	if (closed)
 	{
 		CryLogAlways("$3[CryMP] [ServerPAK] Unloaded $6%s", m_path.c_str());

--- a/Code/CryMP/Server/SSM.h
+++ b/Code/CryMP/Server/SSM.h
@@ -1,17 +1,17 @@
 #pragma once
+
 #include <string>
 #include <optional>
 
+#include "CryCommon/CryAction/IGameRulesSystem.h"
 #include "CryCommon/CryEntitySystem/EntityId.h"
 
 struct IActor;
-struct IGameRules;
 struct INetChannel;
-enum EChatMessageType;
 
-struct ISSM {
-public:
-    ~ISSM() = default;
+struct ISSM
+{
+    virtual ~ISSM() = default;
     virtual void OnGameRulesLoad(IGameRules * pGR) = 0;
     virtual void OnGameRulesUnload(IGameRules* pGR) = 0;
     virtual void Update(float dt) = 0;

--- a/Code/CryMP/Server/SafeWriting/SafeWriting.h
+++ b/Code/CryMP/Server/SafeWriting/SafeWriting.h
@@ -9,7 +9,7 @@ class FunctionRegisterer;
 
 class CSafeWriting : public ISSM {
     bool m_initialized = false;
-    std::shared_ptr<SafeWritingAPI> m_pAPI;
+    std::unique_ptr<SafeWritingAPI> m_pAPI;
     std::unique_ptr<FunctionRegisterer> m_pFR;
 public:
     CSafeWriting(IGameFramework *pFW, ISystem *pSystem);

--- a/Code/CryMP/Server/Server.cpp
+++ b/Code/CryMP/Server/Server.cpp
@@ -34,41 +34,22 @@ void Server::Init(IGameFramework* pGameFramework)
 
 	pGameFramework->RegisterListener(this, "crymp-server", FRAMEWORKLISTENERPRIORITY_DEFAULT);
 
-	CGame* cGame = NULL;
-
-	if (WinAPI::CmdLine::HasArg("-oldgame"))
-	{
-		void* pCryGame = WinAPI::DLL::Load("CryGame.dll");
-		if (!pCryGame)
-		{
-			throw StringTools::SysErrorFormat("Failed to load the CryGame DLL!");
-		}
-
-		auto entry = static_cast<IGame::TEntryFunction>(WinAPI::DLL::GetSymbol(pCryGame, "CreateGame"));
-		if (!entry)
-		{
-			throw StringTools::ErrorFormat("The CryGame DLL is not valid!");
-		}
-
-		this->pGame = entry(pGameFramework);
-	}
-	else
-	{
-		cGame = new CGame();
-		this->pGame = cGame;
-	}
-
 	// initialize the game
 	// mods are not supported
+	this->pGame = new CGame();
 	this->pGame->Init(pGameFramework);
 
-	if (cGame) {
-		if (WinAPI::CmdLine::HasArg("-ssm")) {
-			std::string ssm{ WinAPI::CmdLine::GetArgValue("-ssm") };
-			CryLogAlways("$6[CryMP] Detected SSM: %s", ssm.c_str());
-			if (ssm == "SafeWriting") {
-				cGame->SetSSM(new CSafeWriting(pGameFramework, pGameFramework->GetISystem()));
-			}
+	const std::string ssm(WinAPI::CmdLine::GetArgValue("-ssm"));
+	if (!ssm.empty())
+	{
+		CryLogAlways("$6[CryMP] Detected SSM: %s", ssm.c_str());
+		if (ssm == "SafeWriting")
+		{
+			this->pGame->SetSSM(new CSafeWriting(pGameFramework, pGameFramework->GetISystem()));
+		}
+		else
+		{
+			throw StringTools::ErrorFormat("Unknown SSM: %s", ssm.c_str());
 		}
 	}
 

--- a/Code/CryMP/Server/Server.h
+++ b/Code/CryMP/Server/Server.h
@@ -6,15 +6,15 @@
 
 #include "CryCommon/CryAction/IGameFramework.h"
 
+class CGame;
 class Executor;
 class HTTPClient;
-
 class ScriptBind_CPPAPI;
 
 class Server : public IGameFrameworkListener
 {
 public:
-	IGame *pGame = nullptr;
+	CGame *pGame = nullptr;
 	IGameFramework* pGameFramework = nullptr;
 
 	std::unique_ptr<Executor> pExecutor;

--- a/Code/CrySystem/CryPak.h
+++ b/Code/CrySystem/CryPak.h
@@ -22,7 +22,9 @@ class CryPak final : public ICryPak
 {
 	enum class Priority
 	{
-		NORMAL, HIGH
+		NORMAL,
+		CLIENT_PAK,
+		SERVER_PAK,  // highest priority
 	};
 
 	enum
@@ -256,7 +258,9 @@ public:
 	void SetGameFolderWritable(bool writable) { m_gameFolderWritable = writable; }
 	bool IsGameFolderWritable() const { return m_gameFolderWritable; }
 
-	void LoadInternalPak(const void* data, std::size_t size);
+	bool LoadClientPak(const void* data, std::size_t size);
+	bool LoadServerPak(std::string_view path);
+	bool UnloadServerPak(std::string_view path);
 
 	void AddRedirect(std::string_view path, std::string_view newPath);
 	void RemoveRedirect(std::string_view path);
@@ -277,7 +281,7 @@ private:
 
 	bool OpenFindImpl(SlotGuard<FindSlot>& find);
 
-	bool OpenPakImpl(SlotGuard<PakSlot>& pak);
+	bool OpenPakImpl(SlotGuard<PakSlot>& pak, Priority priority);
 
 	PakSlot* FindLoadedPakByPath(std::string_view pakPath);
 

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -184,7 +184,7 @@ static ICryPak* CreateNewCryPak(ISystem* pSystem, CryPakConfig* config, bool lvl
 	// TODO: config
 	// TODO: lvlRes
 	pCryPak->SetGameFolderWritable(gameFolderWritable);
-	pCryPak->LoadInternalPak(internalPak.data(), internalPak.size());
+	pCryPak->LoadClientPak(internalPak.data(), internalPak.size());
 
 	return pCryPak;
 }

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -1089,15 +1089,11 @@ void Launcher::PatchEngine()
 		MemoryPatch::CrySystem::EnableServerPhysicsThread(m_dlls.pCrySystem);
 		MemoryPatch::CrySystem::HookCryWarning(m_dlls.pCrySystem, &OnCryWarning);
 
-		if (!WinAPI::CmdLine::HasArg("-oldss"))
-		{
-			ReplaceScriptSystem(m_dlls.pCrySystem);
-		}
-
 		InstallEarlyEngineInitHook(m_dlls.pCrySystem);
 
 		ReplaceCryPak(m_dlls.pCrySystem);
 		ReplaceStreamEngine(m_dlls.pCrySystem);
+		ReplaceScriptSystem(m_dlls.pCrySystem);
 		ReplaceHardwareMouse(m_dlls.pCrySystem);
 		ReplaceLocalizationManager(m_dlls.pCrySystem);
 	}

--- a/Code/Launcher/Launcher.cpp
+++ b/Code/Launcher/Launcher.cpp
@@ -1342,12 +1342,10 @@ void Launcher::Run()
 		throw StringTools::ErrorFormat("Invalid name of the executable!");
 	}
 
-#ifdef CLIENT_LAUNCHER
 	if (WinAPI::CmdLine::HasArg("-mod"))
 	{
 		throw StringTools::ErrorFormat("Mods are not supported!");
 	}
-#endif
 
 	this->InitWorkingDirectory();
 


### PR DESCRIPTION
As requested in #325, server PAK now has the highest priority. Even higher than client PAK (internal PAK in the EXE). That means servers are now able to override the client PAK content.

The other changes are the removal of deprecated `-oldgame` and `-oldss` command line options and minor refactoring.