### PR TITLE
72 sometimes rockets go through staticterrain

### DIFF
--- a/Code/CryGame/GameCVars.cpp
+++ b/Code/CryGame/GameCVars.cpp
@@ -640,6 +640,7 @@ void SCVars::InitCVars(IConsole* pConsole)
 	pConsole->Register("mp_recycleProjectiles", &mp_recycleProjectiles, 1, VF_NOT_NET_SYNCED/*VF_CHEAT*/, "Recycle projectiles");
 	pConsole->Register("mp_abandonTime", &mp_abandonTime, 10.f, VF_NOT_NET_SYNCED/*VF_CHEAT*/, "Time in seconds after which vehicles explode");
 	pConsole->Register("mp_explosiveRemovalTime", &mp_explosiveRemovalTime, 30.f, VF_NOT_NET_SYNCED/*VF_CHEAT*/, "Time in seconds for explosive removal after death");
+	pConsole->Register("mp_explosion_mfx", &mp_explosion_mfx, 1, VF_NOT_NET_SYNCED, "Enable mfx via ClExplosion rmi for server controlled missiles");
 }
 
 //------------------------------------------------------------------------

--- a/Code/CryGame/GameCVars.h
+++ b/Code/CryGame/GameCVars.h
@@ -476,6 +476,7 @@ struct SCVars
 	int         mp_recycleProjectiles;
 	float		mp_abandonTime;
 	float		mp_explosiveRemovalTime;
+	int         mp_explosion_mfx;
 
 	SCVars();
 	~SCVars();

--- a/Code/CryGame/GameRules.h
+++ b/Code/CryGame/GameRules.h
@@ -1052,7 +1052,13 @@ protected:
 
 	// Some explosion processing
 	void ProcessClientExplosionScreenFX(const ExplosionInfo &explosionInfo);
-	void ProcessExplosionMaterialFX(const ExplosionInfo &explosionInfo);
+	void ProcessExplosionMaterialFX(const ExplosionInfo& explosionInfo);
+
+	//CryMP mfx
+	bool IntersectSegWithZPlane(const Vec3& p, const Vec3& seg, float planeZ, float& tOut, Vec3& hitOut) const;
+	void PlayMFXFromExplosionInfo(const ExplosionInfo& info);
+	void OnCollisionLogged_MaterialFX(const EventPhys* pEvent);
+	IRenderNode* GetRenderNodeFromCollider(IPhysicalEntity* pCollider);
 
 	// fill source/target dependent params in m_collisionTable
 	void PrepCollision(int src, int trg, const SGameCollision& event, IEntity* pTarget);

--- a/Code/CryGame/GameRulesClientServer.cpp
+++ b/Code/CryGame/GameRulesClientServer.cpp
@@ -27,6 +27,7 @@ History:
 #include "CryCommon/CryAction/IMaterialEffects.h"
 #include "CryCommon/CryAction/IGameplayRecorder.h"
 #include "CryCommon/CryEntitySystem/EntityId.h"
+#include "CryCommon/CrySystem/IConsole.h"
 
 #include "Items/Weapons/Weapon.h"
 #include "Items/Weapons/WeaponSystem.h"
@@ -39,6 +40,8 @@ History:
 #include "Library/Util.h"
 
 #include "CryMP/Server/SSM.h"
+#include "Items/Weapons/Projectiles/Bullet.h"
+#include "CryCommon/Cry3DEngine/IFoliage.h"
 
 
 //------------------------------------------------------------------------
@@ -571,8 +574,41 @@ void CGameRules::ClientExplosion(const ExplosionInfo& explosionInfo)
 		}
 	}
 
-	ProcessClientExplosionScreenFX(explosionInfo);
-	ProcessExplosionMaterialFX(explosionInfo);
+	if (gEnv->bClient)
+	{
+		ProcessClientExplosionScreenFX(explosionInfo);
+		ProcessExplosionMaterialFX(explosionInfo);
+
+		if (gEnv->bMultiplayer && !gEnv->bServer)
+		{
+			bool serverCustomParticleValid = false;
+			if (!explosionInfo.effect_class.empty())
+			{
+				if (IEntityClassRegistry* cr = gEnv->pEntitySystem->GetClassRegistry())
+				{
+					if (IEntityClass* cls = cr->FindClass(explosionInfo.effect_class.c_str()))
+					{
+						const SAmmoParams* pAmmo = g_pGame->GetWeaponSystem()->GetAmmoParams(cls);
+						if (pAmmo)
+						{
+							serverCustomParticleValid = (explosionInfo.pParticleEffect != nullptr && pAmmo->pExplosion && pAmmo->pExplosion->pParticleEffect != explosionInfo.pParticleEffect);
+						}
+					}
+				}
+			}
+
+			//CryMP: If server sets a custom valid explosion effect, don't play the original effect on top of it
+			if (!serverCustomParticleValid)
+			{
+				//CryMP: In multiplayer, play explosion FX from ClExplosion if ammo supports it
+				PlayMFXFromExplosionInfo(explosionInfo);
+			}
+			//else
+			//{
+				//CryLogAlways("Skipping MFX from explosion because server is using custom particle effect! (%s)", explosionInfo.pParticleEffect ? explosionInfo.pParticleEffect->GetName() : "nullptr");
+			//}
+		}
+	}
 
 	IEntity* pShooter = m_pEntitySystem->GetEntity(explosionInfo.shooterId);
 	if (gEnv->pAISystem && !gEnv->bMultiplayer)
@@ -752,7 +788,9 @@ void CGameRules::ProcessExplosionMaterialFX(const ExplosionInfo& explosionInfo)
 
 	string query = effectClass + "_explode";
 	if (gEnv->p3DEngine->GetWaterLevel(&explosionInfo.pos) > explosionInfo.pos.z)
+	{
 		query = query + "_underwater";
+	}
 
 	IMaterialEffects* pMaterialEffects = gEnv->pGame->GetIGameFramework()->GetIMaterialEffects();
 	TMFXEffectId effectId = pMaterialEffects->GetEffectId(query.c_str(), params.trgSurfaceId);
@@ -761,8 +799,680 @@ void CGameRules::ProcessExplosionMaterialFX(const ExplosionInfo& explosionInfo)
 		effectId = pMaterialEffects->GetEffectId(query.c_str(), pMaterialEffects->GetDefaultSurfaceIndex());
 
 	if (effectId != InvalidEffectId)
+	{
 		pMaterialEffects->ExecuteEffect(effectId, params);
+	}
+	return;
 }
+
+//---------------------------------------------------
+// Helper: segment-plane (z = planeZ) intersection
+//---------------------------------------------------
+bool CGameRules::IntersectSegWithZPlane(const Vec3& p, const Vec3& seg, float planeZ, float& tOut, Vec3& hitOut) const
+{
+	const float denom = seg.z;
+	if (fabs_tpl(denom) < 1e-6f)
+		return false;
+	const float t = (planeZ - p.z) / denom;
+	if (t < 0.0f || t > 1.0f)
+		return false;
+	tOut = t;
+	hitOut = p + seg * t;
+	return true;
+}
+
+//---------------------------------------------------
+void CGameRules::PlayMFXFromExplosionInfo(const ExplosionInfo& info)
+{
+	CProjectile* pProj = g_pGame->GetWeaponSystem()->GetProjectile(info.weaponId);
+	if (!pProj || !pProj->IsPlayingMfxFromClExplosion())
+		return;
+
+	const Vec3 pos = info.pos;
+
+	Vec3 intoSurf = info.dir.GetNormalizedSafe(Vec3(0, 0, 1));
+
+	IEntity* pSrcEnt = gEnv->pEntitySystem->GetEntity(info.weaponId);
+	IPhysicalEntity* peSrc = pSrcEnt ? pSrcEnt->GetPhysics() : nullptr;
+
+	// Ammo params
+	const SAmmoParams* pAmmo = nullptr;
+	if (!info.effect_class.empty())
+	{
+		if (IEntityClassRegistry* cr = gEnv->pEntitySystem->GetClassRegistry())
+		{
+			if (IEntityClass* cls = cr->FindClass(info.effect_class.c_str()))
+			{
+				pAmmo = g_pGame->GetWeaponSystem()->GetAmmoParams(cls);
+			}
+		}
+	}
+	if (!pAmmo && pSrcEnt)
+	{
+		pAmmo = g_pGame->GetWeaponSystem()->GetAmmoParams(pSrcEnt->GetClass());
+	}
+
+	// Single forward ray probe
+	ray_hit rh; memset(&rh, 0, sizeof(rh));
+	const int objTypes = ent_all;
+	const int flags = rwi_colltype_any | rwi_stop_at_pierceable;
+
+	IPhysicalEntity* skip[1] = { peSrc };
+	const int nSkip = peSrc ? 1 : 0;
+
+	const Vec3 fwdStart = pos - intoSurf * 0.25f;
+	const Vec3 fwdSeg = intoSurf * 10.0f;
+
+	const int hits = gEnv->pPhysicalWorld->RayWorldIntersection(fwdStart, fwdSeg, objTypes, flags, &rh, 1, skip, nSkip);
+
+	// Prepare EventPhysCollision to forward to OnCollisionLogged_MaterialFX
+	EventPhysCollision c;
+	c.idCollider = 0;
+
+	// Resolve contact point surface normal 
+	const float waterLevelAcc = gEnv->p3DEngine->GetWaterLevel(&pos);
+	const bool insideWater = (pos.z < waterLevelAcc);
+	const bool waterNearby = fabs_tpl(pos.z - waterLevelAcc) < 2.0f;
+
+	Vec3 pt = pos;
+	Vec3 nrm = intoSurf; 
+	bool usedWater = false;
+
+	if (hits > 0 && rh.pCollider)
+	{
+		pt = rh.pt;
+
+		// If water is in front of the solid along the same probe, prefer it
+		if (waterNearby)
+		{
+			float tW; Vec3 hitW;
+			if (IntersectSegWithZPlane(fwdStart, fwdSeg, waterLevelAcc, tW, hitW))
+			{
+				const float segLen = fwdSeg.GetLength();
+				const float tSolid = (segLen > 1e-6f) ? (rh.dist / segLen) : 2.0f;
+				if (tW <= tSolid + 1e-4f)
+				{
+					pt = hitW; pt.z = waterLevelAcc - 0.02f;
+					nrm = Vec3(0, 0, 1);
+					usedWater = true;
+				}
+			}
+		}
+
+		if (!usedWater)
+		{
+			nrm = rh.n; // outward surface normal
+		}
+	}
+	else
+	{
+		// No solid hit; if in/near water, use water plane; else leave defaults
+		if (insideWater || waterNearby)
+		{
+			float tW; Vec3 hitW;
+			if (IntersectSegWithZPlane(fwdStart, fwdSeg, waterLevelAcc, tW, hitW))
+			{
+				pt = hitW; pt.z = waterLevelAcc - 0.02f;
+				nrm = Vec3(0, 0, 1);
+				usedWater = true;
+			}
+			else
+			{
+				pt = pos; pt.z = waterLevelAcc - 0.02f;
+				nrm = Vec3(0, 0, 1);
+				usedWater = true;
+			}
+		}
+	}
+
+	// Pass point and surface normal
+	c.pt = pt;
+	c.n = nrm;
+
+	// Set velocities for backface test: vloc[0] should be the projectile world-velocity
+	if (info.impact && info.impact_velocity.len2() > 1e-6f)
+	{
+		c.vloc[0] = info.impact_velocity; // world-space projectile velocity
+	}
+	else if (peSrc)
+	{
+		pe_status_dynamics sd;
+		c.vloc[0] = (peSrc->GetStatus(&sd) ? sd.v : info.dir * 120.0f);
+	}
+	else
+	{
+		c.vloc[0] = info.dir * 120.0f;
+	}
+
+	// Target velocity (if any) 
+	c.vloc[1] = Vec3(ZERO);
+	if (rh.pCollider)
+	{
+		pe_status_dynamics sdT;
+		if (rh.pCollider->GetStatus(&sdT))
+			c.vloc[1] = sdT.v;
+	}
+
+	// Masses & part ids
+	c.mass[0] = (pAmmo && pAmmo->mass > 0.f) ? pAmmo->mass : 0.05f;
+	c.mass[1] = 0.0f;
+	c.partid[0] = 0;
+	c.partid[1] = rh.partid;
+
+	// Materials
+	IMaterialEffects* pMFX = gEnv->pGame->GetIGameFramework()->GetIMaterialEffects();
+	const int defaultSurf = pMFX->GetDefaultSurfaceIndex();
+
+	int srcSurf = defaultSurf;
+	if (pAmmo && pAmmo->pSurfaceType)
+	{
+		const int sfid = pAmmo->pSurfaceType->GetId();
+		if (sfid > 0) srcSurf = sfid;
+	}
+	c.idmat[0] = srcSurf;
+
+	const int waterId = CBullet::GetWaterMaterialId();
+
+	// Bind target material & foreign data so decals orient correctly
+	if (usedWater)
+	{
+		c.idmat[1] = (waterId > 0) ? waterId : defaultSurf;
+		c.pEntity[1] = gEnv->pPhysicalWorld->AddGlobalArea();
+		c.iForeignData[1] = 0;
+		c.pForeignData[1] = nullptr;
+	}
+	else if (rh.pCollider)
+	{
+		c.idmat[1] = rh.surface_idx;
+		c.pEntity[1] = rh.pCollider;
+
+		if (IEntity* hitEnt = gEnv->pEntitySystem->GetEntityFromPhysics(rh.pCollider))
+		{
+			c.iForeignData[1] = PHYS_FOREIGN_ID_ENTITY;
+			c.pForeignData[1] = hitEnt;
+
+		   // --- ACTOR-FACING NORMAL FIX ---
+			if (IActor* pHitActor = gEnv->pGame->GetIGameFramework()->GetIActorSystem()->GetActor(hitEnt->GetId()))
+			{
+				if (nrm.Dot(intoSurf) > 0.0f)
+				{
+					nrm = -nrm;
+					c.n = nrm;
+				}
+			}
+			// --- END FIX ---
+		}
+		else
+		{
+			c.iForeignData[1] = PHYS_FOREIGN_ID_STATIC;
+			c.pForeignData[1] = GetRenderNodeFromCollider(rh.pCollider);
+		}
+	}
+	else
+	{
+		// Nothing solid and no water → use defaults; CE3 code will handle gracefully
+		c.idmat[1] = defaultSurf;
+		c.pEntity[1] = nullptr;
+		c.iForeignData[1] = 0;
+		c.pForeignData[1] = nullptr;
+	}
+
+	// Source binding
+	c.pEntity[0] = peSrc;
+	c.iForeignData[0] = pSrcEnt ? PHYS_FOREIGN_ID_ENTITY : 0;
+	c.pForeignData[0] = pSrcEnt;
+
+	c.penetration = 0.f;
+	c.normImpulse = 0.f;
+	c.radius = 0.f;
+
+	OnCollisionLogged_MaterialFX((const EventPhys*)&c);
+}
+
+//---------------------------------------------------
+IRenderNode* CGameRules::GetRenderNodeFromCollider(IPhysicalEntity* pCollider)
+{
+	if (!pCollider)
+		return nullptr;
+
+	pe_params_foreign_data fd;
+	if (!pCollider->GetParams(&fd))
+		return nullptr;
+
+	switch (fd.iForeignData)
+	{
+	case PHYS_FOREIGN_ID_ENTITY:
+	{
+		IEntity* pEntity = static_cast<IEntity*>(pCollider->GetForeignData(PHYS_FOREIGN_ID_ENTITY));
+		if (!pEntity)
+		{
+			pEntity = gEnv->pEntitySystem->GetEntityFromPhysics(pCollider);
+		}
+		if (pEntity)
+		{
+			if (IEntityRenderProxy* pRenderProxy = static_cast<IEntityRenderProxy*>(pEntity->GetProxy(ENTITY_PROXY_RENDER)))
+			{
+				return pRenderProxy->GetRenderNode();
+			}
+		}
+		break;
+	}
+	case PHYS_FOREIGN_ID_STATIC:
+	case PHYS_FOREIGN_ID_TERRAIN:
+		return static_cast<IRenderNode*>(pCollider->GetForeignData(fd.iForeignData));
+
+	case PHYS_FOREIGN_ID_FOLIAGE:
+	{
+		IFoliage* pFoliage = static_cast<IFoliage*>(fd.pForeignData);
+		return pFoliage ? pFoliage->GetIRenderNode() : nullptr;
+	}
+	default:
+		break;
+	}
+
+	return nullptr;
+}
+
+//---------------------------------------------------
+void CGameRules::OnCollisionLogged_MaterialFX(const EventPhys* pEvent)
+{
+	const EventPhysCollision* pCEvent = (const EventPhysCollision*)pEvent;
+
+	if ((CBullet::GetWaterMaterialId() && pCEvent->idmat[1] == CBullet::GetWaterMaterialId()) &&
+		(pCEvent->pEntity[1] == gEnv->pPhysicalWorld->AddGlobalArea() && gEnv->p3DEngine->GetVisAreaFromPos(pCEvent->pt)))
+		return;
+
+	const auto GetEnt = [](int i, void* p) -> IEntity*
+		{
+			return (i == PHYS_FOREIGN_ID_ENTITY) ? static_cast<IEntity*>(p) : nullptr;
+		};
+
+	Vec3 dir = ZERO;
+	if (pCEvent->vloc[0].GetLengthSquared() > 1e-6f)
+	{
+		dir = pCEvent->vloc[0].GetNormalized();
+	}
+
+	bool backface = (pCEvent->n.Dot(dir) >= 0);
+
+	// track contacts info for physics sounds generation
+	//CryMP: Commented this out, we dont have SEntityCollHist
+	/*
+	Vec3 vrel, r;
+	float velImpact, velSlide2, velRoll2;
+	pe_status_dynamics sd;
+	int iop, id, i;
+	SEntityCollHist* pech = 0;
+	std::map<int, SEntityCollHist*>::iterator iter;
+
+	iop = inrange(pCEvent->mass[1], 0.0f, pCEvent->mass[0]);
+	id = gEnv->pPhysicalWorld->GetPhysicalEntityId(pCEvent->pEntity[iop]);
+	if ((iter = s_this->m_mapECH.find(id)) != s_this->m_mapECH.end())
+		pech = iter->second;
+	else if (s_this->m_pFreeCHSlot0->pnext != s_this->m_pFreeCHSlot0)
+	{
+		pech = s_this->m_pFreeCHSlot0->pnext;
+		s_this->m_pFreeCHSlot0->pnext = pech->pnext;
+		pech->pnext = 0;
+		pech->timeRolling = pech->timeNotRolling = pech->rollTimeout = pech->slideTimeout = 0;
+		pech->velImpact = pech->velSlide2 = pech->velRoll2 = 0;
+		pech->imatImpact[0] = pech->imatImpact[1] = pech->imatSlide[0] = pech->imatSlide[1] = pech->imatRoll[0] = pech->imatRoll[1] = 0;
+		pech->mass = 0;
+		s_this->m_mapECH.insert(std::pair<int, SEntityCollHist*>(id, pech));
+	}
+
+	if (pech && pCEvent->pEntity[iop]->GetStatus(&sd))
+	{
+		vrel = pCEvent->vloc[iop ^ 1] - pCEvent->vloc[iop];
+		r = pCEvent->pt - sd.centerOfMass;
+		if (sd.w.len2() > 0.01f)
+			r -= sd.w * ((r * sd.w) / sd.w.len2());
+		velImpact = fabs_tpl(vrel * pCEvent->n);
+		velSlide2 = (vrel - pCEvent->n * velImpact).len2();
+		velRoll2 = (sd.w ^ r).len2();
+		pech->mass = pCEvent->mass[iop];
+
+		i = isneg(pech->velImpact - velImpact);
+		pech->imatImpact[0] += pCEvent->idmat[iop] - pech->imatImpact[0] & -i;
+		pech->imatImpact[1] += pCEvent->idmat[iop ^ 1] - pech->imatImpact[1] & -i;
+		pech->velImpact = max(pech->velImpact, velImpact);
+
+		i = isneg(pech->velSlide2 - velSlide2);
+		pech->imatSlide[0] += pCEvent->idmat[iop] - pech->imatSlide[0] & -i;
+		pech->imatSlide[1] += pCEvent->idmat[iop ^ 1] - pech->imatSlide[1] & -i;
+		pech->velSlide2 = max(pech->velSlide2, velSlide2);
+
+		i = isneg(max(pech->velRoll2 - velRoll2, r.len2() * sqr(0.97f) - sqr(r * pCEvent->n)));
+		pech->imatRoll[0] += pCEvent->idmat[iop] - pech->imatRoll[0] & -i;
+		pech->imatSlide[1] += pCEvent->idmat[iop ^ 1] - pech->imatRoll[1] & -i;
+		pech->velRoll2 += (velRoll2 - pech->velRoll2) * i;
+	}
+	*/
+	// --- Begin Material Effects Code ---
+	// Relative velocity, adjusted to be between 0 and 1 for sound effect parameters.
+	static ICVar* mfx_Debug = gEnv->pConsole->GetCVar("mfx_Debug");
+	const int debug = mfx_Debug->GetIVal() > 0;
+
+	float adjustedRelativeVelocity = 0.0f;
+	float impactVelSquared = (pCEvent->vloc[0] - pCEvent->vloc[1]).GetLengthSquared();
+
+	// Anything faster than 15 m/s is fast enough to consider maximum speed
+	adjustedRelativeVelocity = (float)min(1.0f, impactVelSquared / (15.0f * 15.0f));
+
+	// Relative mass, also adjusted to fit into sound effect parameters.
+	// 100.0 is very heavy, the top end for the mass parameter.
+	float adjustedRelativeMass = (float)min(1.0f, fabsf(pCEvent->mass[0] - pCEvent->mass[1]) / 100.0f);
+
+	static ICVar* mfx_ParticleImpactThresh = gEnv->pConsole->GetCVar("mfx_ParticleImpactThresh");
+	const float particleImpactThresh = mfx_ParticleImpactThresh->GetFVal();
+	float partImpThresh = particleImpactThresh;
+	Vec3 vloc0Dir = pCEvent->vloc[0];
+	vloc0Dir = vloc0Dir.normalize();
+	float testSpeed = (pCEvent->vloc[0] * vloc0Dir.Dot(pCEvent->n)).GetLengthSquared();
+
+	// prevent slow objects from making too many collision events by only considering the velocity towards
+	//  the surface (prevents sliding creating tons of effects)
+	if (impactVelSquared < (25.0f * 25.0f) && testSpeed < (partImpThresh * partImpThresh))
+	{
+		impactVelSquared = 0.0f;
+	}
+
+	//CryLogAlways("BackFace: %d, VelSq: %.2f, ThreshSq: %.2f", backface ? 1 : 0, impactVelSquared, partImpThresh * partImpThresh);
+
+	if (!backface && impactVelSquared > (partImpThresh * partImpThresh))
+	{
+		IEntity* pEntitySrc = GetEnt(pCEvent->iForeignData[0], pCEvent->pForeignData[0]);
+		IEntity* pEntityTrg = GetEnt(pCEvent->iForeignData[1], pCEvent->pForeignData[1]);
+
+		IMaterialEffects* pMaterialEffects = gEnv->pMaterialEffects;
+		TMFXEffectId effectId = InvalidEffectId;
+		const int defaultSurfaceIndex = pMaterialEffects->GetDefaultSurfaceIndex();
+
+		SMFXRunTimeEffectParams params;
+		params.src = pEntitySrc ? pEntitySrc->GetId() : 0;
+		params.trg = pEntityTrg ? pEntityTrg->GetId() : 0;
+		params.srcSurfaceId = pCEvent->idmat[0];
+		params.trgSurfaceId = pCEvent->idmat[1];
+		params.soundSemantic = eSoundSemantic_Physics_Collision;
+
+		if (pCEvent->iForeignData[0] == PHYS_FOREIGN_ID_STATIC)
+		{
+			params.srcRenderNode = (IRenderNode*)pCEvent->pForeignData[0];
+		}
+		if (pCEvent->iForeignData[1] == PHYS_FOREIGN_ID_STATIC)
+		{
+			params.trgRenderNode = (IRenderNode*)pCEvent->pForeignData[1];
+		}
+		if (pEntitySrc && pCEvent->idmat[0] == pMaterialEffects->GetDefaultCanopyIndex())
+		{
+			/*  //CryMP: We dont have s_this->m_treeStatus
+			SVegCollisionStatus* test = s_this->m_treeStatus[params.src];
+			if (!test)
+			{
+				IEntityRenderProxy* rp = (IEntityRenderProxy*)pEntitySrc->GetProxy(ENTITY_PROXY_RENDER);
+				if (rp)
+				{
+					IRenderNode* rn = rp->GetRenderNode();
+					if (rn)
+					{
+						effectId = pMaterialEffects->GetEffectIdByName("vegetation", "tree_impact");
+						s_this->m_treeStatus[params.src] = new SVegCollisionStatus();
+					}
+				}
+			}*/
+		}
+
+		//Prevent the same FX to be played more than once in mfx_Timeout time interval
+		/*
+		static ICVar* mfx_Timeout = gEnv->pConsole->GetCVar("mfx_Timeout");
+		float fTimeOut = mfx_Timeout->GetFVal();
+		for (int k = 0; k < MAX_CACHED_EFFECTS; k++)
+		{
+			SMFXRunTimeEffectParams& cachedParams = s_this->m_lstCachedEffects[k];
+			if (cachedParams.src == params.src && cachedParams.trg == params.trg &&
+				cachedParams.srcSurfaceId == params.srcSurfaceId && cachedParams.trgSurfaceId == params.trgSurfaceId &&
+				cachedParams.srcRenderNode == params.srcRenderNode && cachedParams.trgRenderNode == params.trgRenderNode)
+			{
+				if (GetISystem()->GetITimer()->GetCurrTime() - cachedParams.fLastTime <= fTimeOut)
+					return; // didnt timeout yet
+			}
+		}
+
+		// add it overwriting the oldest one
+		s_this->m_nEffectCounter = (s_this->m_nEffectCounter + 1) & (MAX_CACHED_EFFECTS - 1);
+		*/
+
+
+		//SMFXRunTimeEffectParams& cachedParams = s_this->m_lstCachedEffects[s_this->m_nEffectCounter]; 
+		SMFXRunTimeEffectParams cachedParams;
+		cachedParams.src = params.src;
+		cachedParams.trg = params.trg;
+		cachedParams.srcSurfaceId = params.srcSurfaceId;
+		cachedParams.trgSurfaceId = params.trgSurfaceId;
+		cachedParams.soundSemantic = params.soundSemantic;
+		cachedParams.srcRenderNode = params.srcRenderNode;
+		cachedParams.trgRenderNode = params.trgRenderNode;
+		cachedParams.fLastTime = GetISystem()->GetITimer()->GetCurrTime();
+
+		if (effectId == InvalidEffectId)
+		{
+			const char* pSrcArchetype = (pEntitySrc && pEntitySrc->GetArchetype()) ? pEntitySrc->GetArchetype()->GetName() : 0;
+			const char* pTrgArchetype = (pEntityTrg && pEntityTrg->GetArchetype()) ? pEntityTrg->GetArchetype()->GetName() : 0;
+
+			if (pEntitySrc)
+			{
+				if (pSrcArchetype)
+					effectId = pMaterialEffects->GetEffectId(pSrcArchetype, pCEvent->idmat[1]);
+				if (effectId == InvalidEffectId)
+					effectId = pMaterialEffects->GetEffectId(pEntitySrc->GetClass(), pCEvent->idmat[1]);
+			}
+			if (effectId == InvalidEffectId && pEntityTrg)
+			{
+				if (pTrgArchetype)
+					effectId = pMaterialEffects->GetEffectId(pTrgArchetype, pCEvent->idmat[0]);
+				if (effectId == InvalidEffectId)
+					effectId = pMaterialEffects->GetEffectId(pEntityTrg->GetClass(), pCEvent->idmat[0]);
+			}
+		}
+
+		if (effectId != InvalidEffectId)
+		{
+			//It's a bullet if it is a particle, has small mass and flies at high speed (>100m/s)
+			bool isBullet = pCEvent->pEntity[0] ? (pCEvent->pEntity[0]->GetType() == PE_PARTICLE && pCEvent->vloc[0].len2() > 10000.0f && pCEvent->mass[0] < 1.0f) : false;
+
+			IActor* pActor = nullptr;
+			if (isBullet)
+				pActor = gEnv->pGame->GetIGameFramework()->GetIActorSystem()->GetActor(params.trg);
+			params.pos = pCEvent->pt;
+
+			if (isBullet && pActor && pActor->IsClient())
+			{
+				Vec3 proxyOffset(ZERO);
+				Matrix34 tm = pActor->GetEntity()->GetWorldTM();
+				tm.Invert();
+
+				IMovementController* pMV = pActor->GetMovementController();
+				if (pMV)
+				{
+					SMovementState state;
+					pMV->GetMovementState(state);
+					params.pos = state.eyePosition + (state.eyeDirection.normalize() * 1.0f);
+					params.soundProxyEntityId = params.trg;
+					params.soundProxyOffset = tm.TransformVector((state.eyePosition + (state.eyeDirection * 1.0f)) - state.pos);
+					//Do not play FX in FP
+					params.playflags = MFX_PLAY_ALL & ~MFX_PLAY_PARTICLES;
+				}
+			}
+
+			static ICVar* g_blood = gEnv->pConsole->GetCVar("g_blood");
+
+			// further, prevent ALL particle effects from playing if g_blood = 0
+			if (pActor && g_blood->GetIVal() == 0)
+			{
+				params.playflags = MFX_PLAY_ALL & ~MFX_PLAY_PARTICLES;
+			}
+
+			// Check entity links for a 'Shooter'
+			// if we find one and the local player is the shooter, we don't
+			// need a raycast for sound obstruction/occlusion
+			IEntityLink* pEntityLink = pEntitySrc ? pEntitySrc->GetEntityLinks() : 0;
+			if (pEntityLink)
+			{
+				EntityId clientActorId = g_pGame->GetIGameFramework()->GetClientActorId();
+				while (pEntityLink)
+				{
+					//Entity link is created in CProjectile::SetParams(), do we really need to check for the name (only the id perhaps)?
+					if (strcmp("Shooter", pEntityLink->name) == 0)
+					{
+						if (clientActorId == pEntityLink->entityId)
+							params.soundNoObstruction = true;
+
+						// in any case, we're done
+						break;
+					}
+					pEntityLink = pEntityLink->next;
+				}
+			}
+
+			params.decalPos = pCEvent->pt;
+			params.normal = pCEvent->n;
+			Vec3 dir0 = pCEvent->vloc[0];
+			Vec3 dir1 = pCEvent->vloc[1];
+
+			//Water, ZeroG, ... parameters
+
+			bool inWater = false, zeroG = false;
+			float waterLevel = 0.0f;
+			Vec3 gravity;
+			pe_params_buoyancy pb[4];
+			int nBuoys = gEnv->pPhysicalWorld->CheckAreas(pCEvent->pt, gravity, pb, 4);
+			for (int i = 0; i < nBuoys; i++) if (pb[i].iMedium == 0 && (pCEvent->pt - pb[i].waterPlane.origin) * pb[i].waterPlane.n < 0)
+			{
+				waterLevel = pb[i].waterPlane.origin.z;
+				break;
+			}
+			if (gravity.GetLength() < 0.0001f)
+				zeroG = true;
+
+			Vec3 pos = params.pos;
+			if (waterLevel > 0.0f)
+				inWater = (gEnv->p3DEngine->GetWaterLevel(&pos) > params.pos.z);
+
+			params.inWater = inWater;
+			params.inZeroG = zeroG;
+			params.dir[0] = dir0.normalize();
+			params.dir[1] = dir1.normalize();
+			params.src = pEntitySrc ? pEntitySrc->GetId() : 0;
+			params.trg = pEntityTrg ? pEntityTrg->GetId() : 0;
+			params.partID = pCEvent->partid[1];
+
+			float massMin = 0.0f;
+			float massMax = 500.0f;
+			float paramMin = 0.0f;
+			float paramMax = 1.0f / 3.0f;
+
+			// tiny - bullets
+			if ((pCEvent->mass[0] <= 0.1f) && pCEvent->pEntity[0] && pCEvent->pEntity[0]->GetType() == PE_PARTICLE)
+			{
+				// small
+				massMin = 0.0f;
+				massMax = 0.1f;
+				paramMin = 0.0f;
+				paramMax = 1.0f;
+			}
+			else if (pCEvent->mass[0] < 20.0f)
+			{
+				// small
+				massMin = 0.0f;
+				massMax = 20.0f;
+				paramMin = 0.0f;
+				paramMax = 1.5f / 3.0f;
+			}
+			else if (pCEvent->mass[0] < 200.0f)
+			{
+				// medium
+				massMin = 20.0f;
+				massMax = 200.0f;
+				paramMin = 1.0f / 3.0f;
+				paramMax = 2.0f / 3.0f;
+			}
+			else
+			{
+				// ultra large
+				massMin = 200.0f;
+				massMax = 2000.0f;
+				paramMin = 2.0f / 3.0f;
+				paramMax = 1.0f;
+			}
+
+			float p = min(1.0f, (pCEvent->mass[0] - massMin) / (massMax - massMin));
+			float finalparam = paramMin + (p * (paramMax - paramMin));
+
+			// need to hear bullet impacts
+			params.soundDistanceMult = pCEvent->mass[0] > 1.0f ? (finalparam * finalparam) + ((1.0f - finalparam) * .05f) : 1.0f;
+
+			params.AddSoundParam("mass", finalparam);
+			params.AddSoundParam("speed", adjustedRelativeVelocity);
+
+			pMaterialEffects->ExecuteEffect(effectId, params);
+
+			if (debug != 0)
+			{
+				pEntitySrc = GetEnt(pCEvent->iForeignData[0], pCEvent->pForeignData[0]);
+				pEntityTrg = GetEnt(pCEvent->iForeignData[1], pCEvent->pForeignData[1]);
+
+				ISurfaceTypeManager* pSurfaceTypeManager = gEnv->p3DEngine->GetMaterialManager()->GetSurfaceTypeManager();
+				CryLogAlways("[$3MFX$1] Running effect for:");
+				if (pEntitySrc)
+				{
+					const char* pSrcName = pEntitySrc->GetName();
+					const char* pSrcClass = pEntitySrc->GetClass()->GetName();
+					const char* pSrcArchetype = pEntitySrc->GetArchetype() ? pEntitySrc->GetArchetype()->GetName() : "<none>";
+					CryLogAlways("      : SrcClass=%s SrcName=%s Arch=%s", pSrcClass, pSrcName, pSrcArchetype);
+				}
+				if (pEntityTrg)
+				{
+					const char* pTrgName = pEntityTrg->GetName();
+					const char* pTrgClass = pEntityTrg->GetClass()->GetName();
+					const char* pTrgArchetype = pEntityTrg->GetArchetype() ? pEntityTrg->GetArchetype()->GetName() : "<none>";
+					CryLogAlways("      : TrgClass=%s TrgName=%s Arch=%s", pTrgClass, pTrgName, pTrgArchetype);
+				}
+				CryLogAlways("      : Mat0=%s", pSurfaceTypeManager->GetSurfaceType(pCEvent->idmat[0])->GetName());
+				CryLogAlways("      : Mat1=%s", pSurfaceTypeManager->GetSurfaceType(pCEvent->idmat[1])->GetName());
+				CryLogAlways("impact-speed=%f fx-threshold=%f mass=%f speed=%f", sqrtf(impactVelSquared), partImpThresh, finalparam, adjustedRelativeVelocity);
+			}
+		}
+		else
+		{
+			if (debug != 0)
+			{
+				pEntitySrc = GetEnt(pCEvent->iForeignData[0], pCEvent->pForeignData[0]);
+				pEntityTrg = GetEnt(pCEvent->iForeignData[1], pCEvent->pForeignData[1]);
+
+				ISurfaceTypeManager* pSurfaceTypeManager = gEnv->p3DEngine->GetMaterialManager()->GetSurfaceTypeManager();
+				CryLogAlways("[$8MFX$1] Couldn't find effect for any combination of:");
+				if (pEntitySrc)
+				{
+					const char* pSrcName = pEntitySrc->GetName();
+					const char* pSrcClass = pEntitySrc->GetClass()->GetName();
+					const char* pSrcArchetype = pEntitySrc->GetArchetype() ? pEntitySrc->GetArchetype()->GetName() : "<none>";
+					CryLogAlways("      : SrcClass=%s SrcName=%s Arch=%s", pSrcClass, pSrcName, pSrcArchetype);
+				}
+				if (pEntityTrg)
+				{
+					const char* pTrgName = pEntityTrg->GetName();
+					const char* pTrgClass = pEntityTrg->GetClass()->GetName();
+					const char* pTrgArchetype = pEntityTrg->GetArchetype() ? pEntityTrg->GetArchetype()->GetName() : "<none>";
+					CryLogAlways("      : TrgClass=%s TrgName=%s Arch=%s", pTrgClass, pTrgName, pTrgArchetype);
+				}
+				CryLogAlways("      : Mat0=%s", pSurfaceTypeManager->GetSurfaceType(pCEvent->idmat[0])->GetName());
+				CryLogAlways("      : Mat1=%s", pSurfaceTypeManager->GetSurfaceType(pCEvent->idmat[1])->GetName());
+			}
+		}
+	}
+	// --- End Material Effects Code ---
+}
+
 //------------------------------------------------------------------------
 // RMI
 //------------------------------------------------------------------------

--- a/Code/CryGame/Items/Weapons/AmmoParams.cpp
+++ b/Code/CryGame/Items/Weapons/AmmoParams.cpp
@@ -156,6 +156,7 @@ SAmmoParams::SAmmoParams(const IItemParamsNode* pItemParams_, const IEntityClass
 	: flags(0)
 	, serverSpawn(0)
 	, predictSpawn(0)
+	, clexplosion_mfx(0)
 	, lifetime(0.0f)
 	, showtime(0.0f)
 	, aiType(AIOBJECT_NONE)
@@ -251,6 +252,8 @@ void SAmmoParams::LoadFlagsAndParams()
 		reader.Read("ServerSpawn", serverSpawn);
 		if (serverSpawn)
 			reader.Read("PredictSpawn", predictSpawn);
+
+		reader.Read("clexplosion_mfx", clexplosion_mfx);
 	}
 
 	const IItemParamsNode* paramsNode = pItemParams->GetChild("params");

--- a/Code/CryGame/Items/Weapons/AmmoParams.h
+++ b/Code/CryGame/Items/Weapons/AmmoParams.h
@@ -48,7 +48,7 @@ struct SExplosionParams
 	const char *effectName;
 	float effectScale;
 	string type;
-	int		hitTypeId;
+	int hitTypeId;
 	float maxblurdist;
 
 	SExplosionParams(const IItemParamsNode* explosion);
@@ -91,6 +91,7 @@ struct SAmmoParams
 	unsigned int	flags;
 	int		serverSpawn;
 	int		predictSpawn;
+	int     clexplosion_mfx;
 
 	// common parameters
 	float	lifetime;

--- a/Code/CryGame/Items/Weapons/Projectile.cpp
+++ b/Code/CryGame/Items/Weapons/Projectile.cpp
@@ -96,15 +96,6 @@ bool CProjectile::SetAspectProfile(EEntityAspects aspect, uint8 profile)
 			if (m_pAmmoParams->pParticleParams)
 			{
 				params.pParticle = m_pAmmoParams->pParticleParams;
-
-				/* Disabled for now
-				//CryMP: Fix for projectiles colliding with host 
-				IEntity* pEntity = gEnv->pEntitySystem->GetEntity(g_pGame->GetWeaponSystem()->GetLastHostId());
-				if (IPhysicalEntity *pHostPhys = pEntity ? pEntity->GetPhysics() : nullptr)
-				{
-					params.pParticle->pColliderToIgnore = pHostPhys;
-				}
-				*/
 			}
 
 			GetEntity()->Physicalize(params);
@@ -515,7 +506,7 @@ void CProjectile::SetVelocity(const Vec3& pos, const Vec3& dir, const Vec3& velo
 	{
 		if (m_pAmmoParams->predictSpawn)
 		{
-			return; //CryMP: Fix initial projectile lag, this is already being done on server 
+			return; //CryMP: Fix initial projectile lag, this is already done on server 
 		}
 	}
 
@@ -1296,26 +1287,18 @@ void CProjectile::Ricochet(EventPhysCollision* pCollision)
 	}
 }
 
-
+//==================================================================
 CWeapon* CProjectile::GetWeapon()
 {
 	if (m_weaponId)
 	{
 		IItem* pItem = g_pGame->GetIGameFramework()->GetIItemSystem()->GetItem(m_weaponId);
 		if (pItem)
+		{
 			return static_cast<CWeapon*>(pItem->GetIWeapon());
+		}
 	}
-	return 0;
-}
-
-EntityId CProjectile::GetOwnerId()const
-{
-	return m_ownerId;
-}
-
-float CProjectile::GetSpeed() const
-{
-	return m_pAmmoParams->speed;
+	return nullptr;
 }
 
 //==================================================================
@@ -1397,7 +1380,7 @@ void CProjectile::SetDefaultParticleParams(pe_params_particle* pParams)
 		pParams->q0.SetIdentity();
 		pParams->surface_idx = m_pAmmoParams->pParticleParams->surface_idx;
 		pParams->flags = m_pAmmoParams->pParticleParams->flags;
-		pParams->pColliderToIgnore = NULL;
+		pParams->pColliderToIgnore = nullptr;
 		pParams->iPierceability = m_pAmmoParams->pParticleParams->iPierceability;
 	}
 	else

--- a/Code/CryGame/Items/Weapons/Projectile.h
+++ b/Code/CryGame/Items/Weapons/Projectile.h
@@ -26,8 +26,7 @@ History:
 #include "TracerManager.h"
 #include "Weapon.h"
 #include "AmmoParams.h"
-#include "GameCVars.h"
-
+#include "CryGame/GameCVars.h"
 
 #define MIN_DAMAGE								5
 

--- a/Code/CryGame/Items/Weapons/Projectile.h
+++ b/Code/CryGame/Items/Weapons/Projectile.h
@@ -26,6 +26,7 @@ History:
 #include "TracerManager.h"
 #include "Weapon.h"
 #include "AmmoParams.h"
+#include "GameCVars.h"
 
 
 #define MIN_DAMAGE								5
@@ -104,12 +105,6 @@ public:
 
 	virtual int AttachEffect(bool attach, int id, const char *name=0, const Vec3 &offset=Vec3(0.0f,0.0f,0.0f), const Vec3 &dir=Vec3(0.0f,1.0f,0.0f), float scale=1.0f, bool bParticlePrime = true);
 
-  EntityId GetOwnerId()const;
-
-	float GetSpeed() const;
-	inline float GetLifeTime() const { return m_pAmmoParams? m_pAmmoParams->lifetime : 0.0f; }
-	bool IsPredicted() const { return m_pAmmoParams? m_pAmmoParams->predictSpawn != 0 : false; }
-
 	//IHitListener
 	virtual void OnHit(const HitInfo&);
 	virtual void OnExplosion(const ExplosionInfo&);
@@ -120,21 +115,47 @@ public:
 
 	const SAmmoParams *GetParams() const { return m_pAmmoParams; };
 
-	virtual void InitWithAI( );
+	void InitWithAI();
 
-	bool IsUpdated() const
+	inline EntityId GetOwnerId() const
 	{
-		return gEnv->pTimer->GetCurrTime() - m_lastUpdate < 0.1f;
+		return m_ownerId;
 	}
-
-	bool IsGhost() const
+	inline EntityId GetHostId() const
+	{
+		return m_hostId;
+	}
+	inline float GetSpeed() const
+	{
+		return m_pAmmoParams ? m_pAmmoParams->speed : 0.0f;
+	}
+	inline float GetLifeTime() const
+	{
+		return m_pAmmoParams ? m_pAmmoParams->lifetime : 0.0f;
+	}
+	inline bool IsPredicted() const
+	{
+		return m_pAmmoParams ? m_pAmmoParams->predictSpawn != 0 : false;
+	}
+	inline IPhysicalEntity* GetPhysicalEntity()
+	{
+		return m_pPhysicalEntity;
+	}
+	inline bool IsGhost() const
 	{
 		return m_ghost;
 	}
-
-	float GetTotalLifeTime()
+	inline float GetTotalLifeTime() const
 	{
 		return m_totalLifetime;
+	}
+	inline bool IsPlayingMfxFromClExplosion() const
+	{
+		if (m_pAmmoParams && m_pAmmoParams->clexplosion_mfx != 0)
+		{
+			return gEnv->bMultiplayer && g_pGameCVars->mp_explosion_mfx != 0;
+		}
+		return false;
 	}
 
 protected:
@@ -197,8 +218,6 @@ protected:
 	IPhysicalEntity* m_pObstructObject = nullptr;
 
 	float m_spawnTime = 0.0f;
-	float m_lastUpdate = 0.0f;
-
 	bool m_netUpdateReceived = false;
 	bool m_ghost = false;
 };

--- a/Code/CryGame/Items/Weapons/Projectiles/Rocket.cpp
+++ b/Code/CryGame/Items/Weapons/Projectiles/Rocket.cpp
@@ -15,7 +15,6 @@ History:
 #include "CryGame/Game.h"
 #include "Bullet.h"
 
-
 //------------------------------------------------------------------------
 CRocket::CRocket()
 	: m_launchLoc(0, 0, 0),
@@ -90,9 +89,12 @@ void CRocket::HandleEvent(const SGameObjectEvent& event)
 
 		}
 
-		IEntity* pTarget = pCollision->iForeignData[1] == PHYS_FOREIGN_ID_ENTITY ? (IEntity*)pCollision->pForeignData[1] : 0;
+		if (pCollision)
+		{
+			IEntity* pTarget = pCollision->iForeignData[1] == PHYS_FOREIGN_ID_ENTITY ? (IEntity*)pCollision->pForeignData[1] : 0;
 
-		Explode(true, true, pCollision->pt, pCollision->n, pCollision->vloc[0], pTarget ? pTarget->GetId() : 0);
+			Explode(true, true, pCollision->pt, pCollision->n, pCollision->vloc[0], pTarget ? pTarget->GetId() : 0);
+		}
 	}
 }
 

--- a/Code/CryGame/Items/Weapons/WeaponSystem.cpp
+++ b/Code/CryGame/Items/Weapons/WeaponSystem.cpp
@@ -866,13 +866,15 @@ void CWeaponSystem::DumpGhostProjectiles()
 		// resolve owner name
 		const IEntity* pOwnerEnt = gEnv->pEntitySystem->GetEntity(p->GetOwnerId());
 		const char* ownerName = pOwnerEnt ? pOwnerEnt->GetName() : "<no owner>";
+		IGameObject* pGameObject = p->GetGameObject();
+		const uint8_t slotEnables = pGameObject ? pGameObject->GetUpdateSlotEnables(p, eIUS_General) : 0;
 
 		CryLogAlways("[%03d] class=%-25s owner=%-21s $1remote=%d updated=%d",
 			idx,
 			className,
 			ownerName,
-			static_cast<int>(p->IsRemote()),
-			static_cast<int>(p->IsUpdated())
+			static_cast<int>(p->IsRemote(),
+			slotEnables)
 		);
 
 		++idx;

--- a/Pak/Scripts/Entities/Items/XML/Ammo/A2AHomingMissile.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/A2AHomingMissile.xml
@@ -6,6 +6,7 @@
 	<flags>
 		<param name="serverspawn" value="1" />
 		<param name="predictspawn" value="1" />
+		<param name="clexplosion_mfx" value="1" />
 	</flags>
 	<physics type="particle">
 		<param name="mass" value="20" />

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Turret_Rocket.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Turret_Rocket.xml
@@ -1,20 +1,19 @@
-<ammo name="rocket" class="HomingMissile" configuration="mp">
+<ammo name="turret_rocket" class="HomingMissile">
 	<geometry>
 		<firstperson name="objects/weapons/rockets/sidewinder/sidewinder.cgf" />
 		<thirdperson name="objects/weapons/rockets/sidewinder/sidewinder.cgf" />
 	</geometry>
 	<flags>
 		<param name="serverspawn" value="1" />
-		<param name="predictspawn" value="1" />
 		<param name="clexplosion_mfx" value="1" />
 	</flags>
 	<physics type="particle">
 		<param name="mass" value="3.5" />
-		<param name="speed" value="30" />
+		<param name="speed" value="45" />
 		<param name="radius" value="0.25" />
 		<param name="air_resistance" value="0" />
 		<param name="water_resistance" value="0.5" />
-		<param name="gravity" value="0, 0, 0" />
+		<param name="gravity" value="0, 0, -0.3" />
 		<param name="water_gravity" value="0, 0, -1" />
 		<param name="thrust" value="25" />
 		<param name="lift" value="0" />
@@ -24,9 +23,9 @@
 		<param name="pierceability" value="8" />
 	</physics>
 	<explosion>
-		<param name="pressure" value="1700" />
-		<param name="min_radius" value="2" />
-		<param name="max_radius" value="5" />
+		<param name="pressure" value="2000" />
+		<param name="min_radius" value="15" />
+		<param name="max_radius" value="20" />
 		<param name="min_phys_radius" value="2.2" />
 		<param name="max_phys_radius" value="3" />
 		<param name="hole_size" value="2" />
@@ -34,17 +33,13 @@
 		<param name="effect" value="" />
 		<param name="effect_scale" value="1" />
 		<param name="radialblurdist" value="30" />
-		<param name="type" value="law_rocket" />
 	</explosion>
 	<params>
-		<param name="lifetime" value="30" />
-		<param name="showtime" value="0.035" />
-		<param name="turn_speed" value="240" />
-		<param name="max_target_distance" value="2000" />
+		<param name="lifetime" value="15" />
+		<param name="showtime" value="0.15" />
+		<param name="turn_speed" value="280" />
+		<param name="max_target_distance" value="500" />
 		<param name="aitype"	value="rpg" />
-		<param name="cruise" value="0" />
-		<param name="controlled" value="1" />
-		<param name="lazyness" value="0.6" />
 	</params>
 	<trail>
 		<param name="effect" value="smoke_and_fire.weapon_Rocket.Trail" />

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/DumbAAMissile.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/DumbAAMissile.xml
@@ -6,6 +6,7 @@
 	<flags>
 		<param name="serverspawn" value="1" />
 		<param name="predictspawn" value="1" />
+		<param name="clexplosion_mfx" value="1" />
 	</flags>
 	<physics type="particle">
 		<param name="mass" value="0.3" />

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/ExocetMissile.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/ExocetMissile.xml
@@ -5,6 +5,7 @@
 	</geometry>
 	<flags>
 		<param name="clientonly" value="1" />
+		<param name="clexplosion_mfx" value="1" />
 	</flags>
 	<physics type="particle">
 		<param name="mass" value="20" />

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/HelicopterMissile.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/HelicopterMissile.xml
@@ -6,6 +6,7 @@
 	<flags>
 		<param name="serverspawn" value="1" />
 		<param name="predictspawn" value="1" />
+		<param name="clexplosion_mfx" value="1" />
 	</flags>
 	<physics type="particle">
 		<param name="mass" value="10" />

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/TOWMissile.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/TOWMissile.xml
@@ -6,6 +6,7 @@
 	<flags>
 		<param name="serverspawn" value="1" />
 		<param name="predictspawn" value="1" />
+		<param name="clexplosion_mfx" value="1" />
 	</flags>
 	<physics type="particle">
 		<param name="mass" value="1" />

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/Tank125.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/Tank125.xml
@@ -6,6 +6,7 @@
 	<flags>
 		<param name="serverspawn" value="1" />
 		<param name="predictspawn" value="1" />
+		<param name="clexplosion_mfx" value="1" />
 	</flags>
 	<physics type="particle">
 		<param name="mass" value="0.35" />

--- a/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/Tank30.xml
+++ b/Pak/Scripts/Entities/Items/XML/Ammo/Multiplayer/Vehicles/Tank30.xml
@@ -6,6 +6,7 @@
 	<flags>
 		<param name="serverspawn" value="1" />
 		<param name="predictspawn" value="1" />
+		<param name="clexplosion_mfx" value="1" />
 	</flags>
 	<physics type="particle">
 		<param name="mass" value="0.25" />


### PR DESCRIPTION
* Fix MP projectile explosion FX not playing because the server removed projectiles before the client registered a collision. Effects/decals now trigger from the **ClExplosion** event instead of per-particle client collisions.

**Changes**

* Added `CGameRules::PlayMFXFromExplosionInfo` (plus small helpers) to drive MaterialFX from `ClExplosion` with a short forward probe for surface/material.
* Imported `OnCollisionLogged_MaterialFX` from CryAction, and try to pass correct **pt/normal/velocities/materials**.
* Actor hits: ensure the normal faces against shot direction for living targets so backface test doesn’t cull the effect.
* Water-aware resolve (prefer water plane if it’s in front of the solid) and cleaner decal projection (no more smeared/oversized ground decals).
* Suppression of legacy client per-particle collision FX when using ClExplosion mfx (avoids duplicates).
* New cvar **`mp_explosion_mfx`** (on/off).
* Ammo flag **`clexplosion_mfx`** (XML) for projectiles that should use the ClExplosion MFX path.

**Behavior**

* In MP (and SP), explosion FX/decals now play reliably even when the projectile entity is removed early by the server.
* If `mp_explosion_mfx=0` or an ammo lacks `clexplosion_mfx`, falls back to legacy behavior.
