### PR TITLE
CI/CD: Fix pipeline in forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,22 +34,6 @@ jobs:
           # for version generator
           fetch-depth: 0
 
-      - name: Get Ninja
-        run: |
-          $url = 'https://api.github.com/repos/ninja-build/ninja/releases/latest'
-          $headers = @{
-            'Authorization' = 'Bearer ${{ secrets.GITHUB_TOKEN }}'
-          }
-          $release = Invoke-RestMethod -Uri $url -Headers $headers
-          $release
-          $asset = $release.assets | where { $_.name -eq 'ninja-win.zip' }
-          $ninja_dir = Join-Path $env:BUILD_DIR 'ninja'
-          $ninja_zip = Join-Path $env:BUILD_DIR 'ninja.zip'
-          New-Item $ninja_dir -ItemType Directory | Out-Null
-          Invoke-WebRequest -Uri $asset.browser_download_url -Headers $headers -OutFile $ninja_zip
-          Expand-Archive $ninja_zip -DestinationPath $ninja_dir
-          'NINJA_DIR=' + $ninja_dir >> $env:GITHUB_ENV
-
       - name: Build
         id: build
         run: |
@@ -58,7 +42,6 @@ jobs:
           Import-Module (Join-Path $vs_path 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
           $arch = if (${{ inputs.bits }} -eq 32) { 'x86' } else { 'amd64' }
           Enter-VsDevShell -VsInstallPath $vs_path -SkipAutomaticLocation -Arch $arch
-          $env:PATH = $env:NINJA_DIR + ';' + $env:PATH
           cmake -S . -B $env:BUILD_DIR -G Ninja -D CMAKE_BUILD_TYPE=${{ inputs.type }}
           cmake --build $env:BUILD_DIR
           $exe_path = Join-Path $env:BUILD_DIR 'CryMP-Client${{ inputs.bits }}.exe'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,6 @@ on:
         description: CMake build type
         required: true
         type: string
-      sign:
-        description: Code signing
-        required: false
-        default: false
-        type: boolean
     outputs:
       artifact_name:
         description: Name of the resulting artifact
@@ -71,7 +66,7 @@ jobs:
           'artifact_name=CryMP-Client${{ inputs.bits }}-' + $version >> $env:GITHUB_OUTPUT
 
       - name: Sign
-        if: inputs.sign
+        if: github.repository_owner == 'crymp-net'
         run: |
           Set-Content -Path bundle.txt -Value '${{ secrets.CODE_SIGNING_PFX }}'
           certutil -decode bundle.txt bundle.pfx

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,7 +16,6 @@ jobs:
     with:
       bits: 32
       type: RelWithDebInfo
-      sign: true
 
   build_64:
     uses: ./.github/workflows/build.yml
@@ -24,7 +23,6 @@ jobs:
     with:
       bits: 64
       type: RelWithDebInfo
-      sign: true
 
   publish:
     if: github.ref == 'refs/heads/master' && github.repository_owner == 'crymp-net'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,6 @@ jobs:
     with:
       bits: 32
       type: RelWithDebInfo
-      sign: true
 
   build_64:
     uses: ./.github/workflows/build.yml
@@ -22,4 +21,3 @@ jobs:
     with:
       bits: 64
       type: RelWithDebInfo
-      sign: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
     with:
       bits: 32
       type: Release
-      sign: true
 
   build_64:
     uses: ./.github/workflows/build.yml
@@ -24,7 +23,6 @@ jobs:
     with:
       bits: 64
       type: Release
-      sign: true
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Skip code signing in forks (and PRs from forks) causing pipeline failure due to missing secrets.
- Remove unnecessary Ninja download because it's [preinstalled](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) now.