### PR TITLE
Fix LAM and Silencer in custom weapons

### DIFF
--- a/Code/CryGame/Items/ItemEvents.cpp
+++ b/Code/CryGame/Items/ItemEvents.cpp
@@ -50,7 +50,13 @@ void CItem::OnEnterFirstPerson()
 
 	for (auto const& accessory : m_accessories)
 	{
-		if (accessory.first == g_pItemStrings->LAM || accessory.first == g_pItemStrings->LAMRifle || accessory.first == g_pItemStrings->LAMFlashLight || accessory.first == g_pItemStrings->LAMRifleFlashLight)
+		if (
+			accessory.first == g_pItemStrings->LAM 
+			|| accessory.first == g_pItemStrings->LAMRifle 
+			|| accessory.first == g_pItemStrings->LAMFlashLight 
+			|| accessory.first == g_pItemStrings->LAMRifleFlashLight 
+			|| std::string_view{ accessory.first.c_str() }.starts_with("LAM")
+		)
 		{
 			CItem* pItem = static_cast<CItem*>(m_pGameFramework->GetIItemSystem()->GetItem(accessory.second));
 			if (pItem)
@@ -74,7 +80,12 @@ void CItem::OnEnterThirdPerson()
 
 	for (auto const& accessory : m_accessories)
 	{
-		if (accessory.first == g_pItemStrings->LAM || accessory.first == g_pItemStrings->LAMRifle || accessory.first == g_pItemStrings->LAMFlashLight || accessory.first == g_pItemStrings->LAMRifleFlashLight)
+		if (
+			accessory.first == g_pItemStrings->LAM 
+			|| accessory.first == g_pItemStrings->LAMRifle 
+			|| accessory.first == g_pItemStrings->LAMFlashLight 
+			|| accessory.first == g_pItemStrings->LAMRifleFlashLight 
+			|| std::string_view{ accessory.first.c_str() }.starts_with("LAM"))
 		{
 			CItem* pItem = static_cast<CItem*>(m_pGameFramework->GetIItemSystem()->GetItem(accessory.second));
 			if (pItem)

--- a/Code/CryGame/Items/ItemEvents.cpp
+++ b/Code/CryGame/Items/ItemEvents.cpp
@@ -55,7 +55,8 @@ void CItem::OnEnterFirstPerson()
 			|| accessory.first == g_pItemStrings->LAMRifle 
 			|| accessory.first == g_pItemStrings->LAMFlashLight 
 			|| accessory.first == g_pItemStrings->LAMRifleFlashLight 
-			|| std::string_view{ accessory.first.c_str() }.starts_with("LAM")
+			// CryMP: allow custom attachments
+			|| accessory.first.sv().starts_with("LAM")
 		)
 		{
 			CItem* pItem = static_cast<CItem*>(m_pGameFramework->GetIItemSystem()->GetItem(accessory.second));
@@ -85,7 +86,8 @@ void CItem::OnEnterThirdPerson()
 			|| accessory.first == g_pItemStrings->LAMRifle 
 			|| accessory.first == g_pItemStrings->LAMFlashLight 
 			|| accessory.first == g_pItemStrings->LAMRifleFlashLight 
-			|| std::string_view{ accessory.first.c_str() }.starts_with("LAM"))
+			// CryMP: allow custom attachments
+			|| accessory.first.sv().starts_with("LAM"))
 		{
 			CItem* pItem = static_cast<CItem*>(m_pGameFramework->GetIItemSystem()->GetItem(accessory.second));
 			if (pItem)

--- a/Code/CryGame/Items/ItemString.h
+++ b/Code/CryGame/Items/ItemString.h
@@ -109,6 +109,10 @@ public:
 		return m_name.data();
 	}
 
+	std::string_view sv() const {
+		return m_name;
+	}
+
 	std::size_t length() const
 	{
 		return m_name.length();

--- a/Code/CryGame/Items/Weapons/Weapon.cpp
+++ b/Code/CryGame/Items/Weapons/Weapon.cpp
@@ -2013,7 +2013,10 @@ void CWeapon::PatchFireModeWithAccessory(IFireMode* pFireMode, const char* firem
 	{
 
 		//Attach silencer (and LAM)
-		if (ait->first == g_pItemStrings->Silencer || ait->first == g_pItemStrings->SOCOMSilencer)
+		if (
+			ait->first == g_pItemStrings->Silencer
+			|| ait->first == g_pItemStrings->SOCOMSilencer
+			|| std::string_view{ ait->first.c_str() }.ends_with("Silencer"))
 			silencerAttached = true;
 
 		SAccessoryParams* params = GetAccessoryParams(ait->first);
@@ -2535,7 +2538,10 @@ EntityId CWeapon::GetLAMAttachment()
 {
 	for (const auto &it : m_accessories)
 	{
-		if (it.first == g_pItemStrings->LAM || it.first == g_pItemStrings->LAMRifle)
+		if (
+			it.first == g_pItemStrings->LAM 
+			|| it.first == g_pItemStrings->LAMRifle 
+			|| std::string_view{ it.first.c_str() }.starts_with("LAM"))
 			return it.second;
 	}
 

--- a/Code/CryGame/Items/Weapons/Weapon.cpp
+++ b/Code/CryGame/Items/Weapons/Weapon.cpp
@@ -2016,7 +2016,8 @@ void CWeapon::PatchFireModeWithAccessory(IFireMode* pFireMode, const char* firem
 		if (
 			ait->first == g_pItemStrings->Silencer
 			|| ait->first == g_pItemStrings->SOCOMSilencer
-			|| std::string_view{ ait->first.c_str() }.ends_with("Silencer"))
+			// CryMP: allow custom attachments
+			|| ait->first.sv().ends_with("Silencer"))
 			silencerAttached = true;
 
 		SAccessoryParams* params = GetAccessoryParams(ait->first);
@@ -2541,7 +2542,9 @@ EntityId CWeapon::GetLAMAttachment()
 		if (
 			it.first == g_pItemStrings->LAM 
 			|| it.first == g_pItemStrings->LAMRifle 
-			|| std::string_view{ it.first.c_str() }.starts_with("LAM"))
+			// CryMP: allow custom LAM attachments (laser-only here)
+			|| (it.first.sv().starts_with("LAM") && !it.first.sv().ends_with("FlashLight"))
+		)
 			return it.second;
 	}
 
@@ -2559,7 +2562,12 @@ EntityId CWeapon::GetFlashlightAttachment()
 {
 	for (const auto& it : m_accessories)
 	{
-		if (it.first == g_pItemStrings->LAMFlashLight || it.first == g_pItemStrings->LAMRifleFlashLight)
+		if (
+			it.first == g_pItemStrings->LAMFlashLight 
+			|| it.first == g_pItemStrings->LAMRifleFlashLight
+			// CryMP: allow custom LAM attachments (flashlight-only here)
+			|| (it.first.sv().starts_with("LAM") && it.first.sv().ends_with("FlashLight"))
+		)
 			return it.second;
 	}
 


### PR DESCRIPTION
There is currently some hardcoded C++ logic for silencers and LAM modules that relies on specific string values. This change makes that logic more generic.

Without this change, LAM attachments on custom weapons would incorrectly trigger crosshair behavior, and silencer logic could break in other cases.

To address this, the logic now uses classname naming conventions: all LAM attachments must begin with `LAM`, while all silencers must end with `Silencer`.