### PR TITLE
SSM SafeWriting clean-up

### DIFF
--- a/SSMs/SafeWriting/CryMP-Server/AdditionalScripts/LevelDesigner.lua
+++ b/SSMs/SafeWriting/CryMP-Server/AdditionalScripts/LevelDesigner.lua
@@ -336,11 +336,6 @@ if SafeWriting and AddChatCommand and Chat and Console and Msg then
 		end
 		if height then pos.z=pos.z+height; end
 		local isValid="EwuvqoCooqRkemwr";
-		local jl1h=JL1Hash:Create(127);
-		if not jl1h:Hash(isValid)=="41fa02" then
-			printf("Name of entity class seems to be corrupted!");
-			return;
-		end
 		local testValid="";
 		for i=1,#isValid do
 			testValid=testValid..string.char(string.byte(isValid,i)-2);
@@ -479,144 +474,144 @@ if SafeWriting and AddChatCommand and Chat and Console and Msg then
 		return ent;
 	end
 	if SafeWriting.NumVersion>=253 then
-	function LevelDesigner:OnTimerTick(player)
-		local bunkers=System.GetEntitiesByClass("SpawnGroup");
-		if bunkers and #bunkers>0 then
-			for i,sp in pairs(bunkers) do
-				if sp.isLDCapturable then
-					local capts=System.GetEntitiesInSphereByClass(sp:GetWorldPos(),19,"Player");
-					if sp.underattack then
-						if not capts or (capts and #capts==0) then
-							sp.allClients:ClCancelUncapture();
-							sp.underattack=false;
-						elseif capts then
-							local enem=0;
-							for i,v in pairs(capts) do
-								if g_gameRules.game:GetTeam(v.id)~=sp.team then
-									enem=enem+1;
-								end
-							end
-							if enem==0 then
+		function LevelDesigner:OnTimerTick(player)
+			local bunkers=System.GetEntitiesByClass("SpawnGroup");
+			if bunkers and #bunkers>0 then
+				for i,sp in pairs(bunkers) do
+					if sp.isLDCapturable then
+						local capts=System.GetEntitiesInSphereByClass(sp:GetWorldPos(),19,"Player");
+						if sp.underattack then
+							if not capts or (capts and #capts==0) then
 								sp.allClients:ClCancelUncapture();
 								sp.underattack=false;
+							elseif capts then
+								local enem=0;
+								for i,v in pairs(capts) do
+									if g_gameRules.game:GetTeam(v.id)~=sp.team then
+										enem=enem+1;
+									end
+								end
+								if enem==0 then
+									sp.allClients:ClCancelUncapture();
+									sp.underattack=false;
+								end
 							end
 						end
 					end
 				end
 			end
 		end
-	end
-	function LevelDesigner:UpdatePlayer(player)
-		local ct=10;
-		if g_gameRules.class~="PowerStruggle" then return; end
-		if player:IsDead() then return; end
-		local bzs=System.GetEntitiesInSphereByClass(player:GetWorldPos(),9,"BuyZone");
-		local sps=System.GetEntitiesInSphereByClass(player:GetWorldPos(),19,"SpawnGroup");
-		if sps and #sps>0 then
-			local sp=sps[1];
-			if sp then
-				local team=g_gameRules.game:GetTeam(player.id);
-				local spt=g_gameRules.game:GetTeam(sp.id);
-				local capts=System.GetEntitiesInSphereByClass(sp:GetWorldPos(),19,"Player");
-				local uscpts=0;
-				local nkcpts=0;
-				for i,v in pairs(capts) do
-					local tm=g_gameRules.game:GetTeam(v.id);
-					if v.host and not v:IsDead() then
-						if tm==1 then nkcpts=nkcpts+1; elseif tm==2 then uscpts=uscpts+1; end
-					end
-				end
-				local enems=false;
-				if team==1 then enems=uscpts>0; else enems=nkcpts>0; end
-				if spt~=team and sp.isLDCapturable then
-					if not enems then
-						sp.cap=sp.cap or 0;
-						if sp.lastcap and (_time-sp.lastcap)>=2 then
-							if spt==0 then sp.cap=0; else sp.cap=ct; end
-							sp.lastcap=_time;
+		function LevelDesigner:UpdatePlayer(player)
+			local ct=10;
+			if g_gameRules.class~="PowerStruggle" then return; end
+			if player:IsDead() then return; end
+			local bzs=System.GetEntitiesInSphereByClass(player:GetWorldPos(),9,"BuyZone");
+			local sps=System.GetEntitiesInSphereByClass(player:GetWorldPos(),19,"SpawnGroup");
+			if sps and #sps>0 then
+				local sp=sps[1];
+				if sp then
+					local team=g_gameRules.game:GetTeam(player.id);
+					local spt=g_gameRules.game:GetTeam(sp.id);
+					local capts=System.GetEntitiesInSphereByClass(sp:GetWorldPos(),19,"Player");
+					local uscpts=0;
+					local nkcpts=0;
+					for i,v in pairs(capts) do
+						local tm=g_gameRules.game:GetTeam(v.id);
+						if v.host and not v:IsDead() then
+							if tm==1 then nkcpts=nkcpts+1; elseif tm==2 then uscpts=uscpts+1; end
 						end
-						if spt==0 then
-							sp.cap=math.min(ct,math.max(sp.cap,0));
-							sp.cap=sp.cap+(_time-(sp.lastcap or _time));
-							MessageStream:SendToTarget(player,"Capturing spawn point: %.2f %%",sp.cap*100/ct);
-							if sp.cap>=ct then
-								sp.team=team;
-								MessageStream:SendToTarget(player,"Successfuly captured spawn point");
-								sp.allClients:ClCapture(team)
-								g_gameRules.game:SetTeam(team,sp.id);
-								sp.lastcap=nil;
-								for i,v in pairs(capts) do
-									local tm=g_gameRules.game:GetTeam(v.id);
-									if tm==team and (not v:IsDead()) then
-										GivePoints(v,PowerStruggle.captureValue[1],PowerStruggle.cpList.CAPTURE)
+					end
+					local enems=false;
+					if team==1 then enems=uscpts>0; else enems=nkcpts>0; end
+					if spt~=team and sp.isLDCapturable then
+						if not enems then
+							sp.cap=sp.cap or 0;
+							if sp.lastcap and (_time-sp.lastcap)>=2 then
+								if spt==0 then sp.cap=0; else sp.cap=ct; end
+								sp.lastcap=_time;
+							end
+							if spt==0 then
+								sp.cap=math.min(ct,math.max(sp.cap,0));
+								sp.cap=sp.cap+(_time-(sp.lastcap or _time));
+								MessageStream:SendToTarget(player,"Capturing spawn point: %.2f %%",sp.cap*100/ct);
+								if sp.cap>=ct then
+									sp.team=team;
+									MessageStream:SendToTarget(player,"Successfuly captured spawn point");
+									sp.allClients:ClCapture(team)
+									g_gameRules.game:SetTeam(team,sp.id);
+									sp.lastcap=nil;
+									for i,v in pairs(capts) do
+										local tm=g_gameRules.game:GetTeam(v.id);
+										if tm==team and (not v:IsDead()) then
+											GivePoints(v,PowerStruggle.captureValue[1],PowerStruggle.cpList.CAPTURE)
+										end
 									end
+								else
+									sp.allClients:ClStepCapture(team,ct-sp.cap);
+									sp.lastcap=_time;
 								end
 							else
-								sp.allClients:ClStepCapture(team,ct-sp.cap);
+								sp.cap=math.min(ct,math.max(sp.cap,0));
+								sp.cap=sp.cap-(_time-(sp.lastcap or _time));
+								if not sp.underattack then
+									sp.allClients:ClStartUncapture(team);
+									sp.underattack=true;
+								end
+								MessageStream:SendToTarget(player,"Uncapturing spawn point: %.2f %%",(ct-math.max(0,sp.cap))*100/ct);
+								if sp.cap<=0 then
+									local oldteam=sp.team;
+									sp.team=0;
+									sp.allClients:ClUncapture(team,oldteam)
+									g_gameRules.game:SetTeam(0,sp.id); 								
+								else
+									sp.allClients:ClStepUncapture(team,sp.cap);
+								end
 								sp.lastcap=_time;
 							end
 						else
-							sp.cap=math.min(ct,math.max(sp.cap,0));
-							sp.cap=sp.cap-(_time-(sp.lastcap or _time));
-							if not sp.underattack then
-								sp.allClients:ClStartUncapture(team);
-								sp.underattack=true;
-							end
-							MessageStream:SendToTarget(player,"Uncapturing spawn point: %.2f %%",(ct-math.max(0,sp.cap))*100/ct);
-							if sp.cap<=0 then
-								local oldteam=sp.team;
-								sp.team=0;
-								sp.allClients:ClUncapture(team,oldteam)
-								g_gameRules.game:SetTeam(0,sp.id); 								
+							sp.cap=sp.cap or 0;
+							if spt==0 then
+								MessageStream:SendToTarget(player,"Capturing spawn point: %.2f %% | Enemies are in zone!",sp.cap*100/ct);
 							else
-								sp.allClients:ClStepUncapture(team,sp.cap);
-							end
+								MessageStream:SendToTarget(player,"Uncapturing spawn point: %.2f %% | Enemies are in zone!",math.max(0,(ct-math.max(0,sp.cap))*100/ct));
+							end	
+							sp.underattack=false;
+							sp.allClients:ClStepUncapture(team,sp.cap);
+							sp.allClients:ClCancelUncapture();
 							sp.lastcap=_time;
 						end
-					else
-						sp.cap=sp.cap or 0;
-						if spt==0 then
-							MessageStream:SendToTarget(player,"Capturing spawn point: %.2f %% | Enemies are in zone!",sp.cap*100/ct);
-						else
-							MessageStream:SendToTarget(player,"Uncapturing spawn point: %.2f %% | Enemies are in zone!",math.max(0,(ct-math.max(0,sp.cap))*100/ct));
-						end	
-						sp.underattack=false;
-						sp.allClients:ClStepUncapture(team,sp.cap);
-						sp.allClients:ClCancelUncapture();
-						sp.lastcap=_time;
+					elseif enems and spt==team and sp.isLDCapturable then
+						MessageStream:SendToTarget(player,"Enemy is uncapturing spawn point: %.2f %%",math.max(0,(ct-math.max(0,sp.cap))*100/ct));
 					end
-				elseif enems and spt==team and sp.isLDCapturable then
-					MessageStream:SendToTarget(player,"Enemy is uncapturing spawn point: %.2f %%",math.max(0,(ct-math.max(0,sp.cap))*100/ct));
+				end
+			end
+			if bzs and #bzs>0 then
+				local bz=bzs[1];
+				local sp=System.GetEntitiesInSphereByClass(bz:GetPos(),20,"SpawnGroup");
+				local myt=g_gameRules.game:GetTeam(player.id);
+				local team=0;
+				if sp and #sp>0 then team=g_gameRules.game:GetTeam(sp[1].id); end
+				if (not player.inRealBZ) and myt==team  then
+					player.wasBefore=player.buyFlags;
+					player.buyFlags=bor(bor(PowerStruggle.BUY_AMMO, PowerStruggle.BUY_WEAPON), PowerStruggle.BUY_EQUIPMENT);
+					player.GetBuyFlags=function(self)
+						return self.buyFlags;
+					end;
+					g_gameRules.factories[1].allClients:ClSetBuyFlags(player.id, player.buyFlags);
+					g_gameRules:OnEnterBuyZone(player, player);
+					g_gameRules:OnEnterServiceZone(player, player);
+					player.inRealBZ=true;
+				end
+			else
+				if player.inRealBZ and (not player.wasBefore) then
+					g_gameRules:OnLeaveBuyZone(player, player);
+					g_gameRules:OnLeaveServiceZone(player, player);
+					player.GetBuyFlags=nil;
+					player.inRealBZ=false;
+					player.buyFlags=nil;
 				end
 			end
 		end
-		if bzs and #bzs>0 then
-			local bz=bzs[1];
-			local sp=System.GetEntitiesInSphereByClass(bz:GetPos(),20,"SpawnGroup");
-			local myt=g_gameRules.game:GetTeam(player.id);
-			local team=0;
-			if sp and #sp>0 then team=g_gameRules.game:GetTeam(sp[1].id); end
-			if (not player.inRealBZ) and myt==team  then
-				player.wasBefore=player.buyFlags;
-				player.buyFlags=bor(bor(PowerStruggle.BUY_AMMO, PowerStruggle.BUY_WEAPON), PowerStruggle.BUY_EQUIPMENT);
-				player.GetBuyFlags=function(self)
-					return self.buyFlags;
-				end;
-				g_gameRules.factories[1].allClients:ClSetBuyFlags(player.id, player.buyFlags);
-				g_gameRules:OnEnterBuyZone(player, player);
-				g_gameRules:OnEnterServiceZone(player, player);
-				player.inRealBZ=true;
-			end
-		else
-			if player.inRealBZ and (not player.wasBefore) then
-				g_gameRules:OnLeaveBuyZone(player, player);
-				g_gameRules:OnLeaveServiceZone(player, player);
-				player.GetBuyFlags=nil;
-				player.inRealBZ=false;
-				player.buyFlags=nil;
-			end
-		end
-	end
 	end	--/if 253
 	function LevelDesigner:CheckPlayer(pl)
 		if self.BuildC[pl.profile] then

--- a/SSMs/SafeWriting/CryMP-Server/LevelDesignerHelper.txt
+++ b/SSMs/SafeWriting/CryMP-Server/LevelDesignerHelper.txt
@@ -155,11 +155,11 @@ Version 7:
 	Now you can make spawnpoints those are capturable by teams by spawning :SpawnGroup ... !ldf 0 :SpawnGroup
 	To add buy zones to them, spawn :BuyZone ... !ldf 0 :BuyZone
 	+ needs mod update to 2.5.3
-version 8:
+Version 8:
 	Works on 64bit
 	Can freeze entities,cloak,... by writing "frozen:", "dynfrozen:", "cloak:", "wet:" before their name, like !ldf 0 frozen:cafe or !ldf 0 frozen::US_vtol
 	To freeze... all entities, simply use "all" as name of object, like !ldf 0 frozen:all
-version 9:
+Version 9:
 	Can shoot terrain and all non-entities with LDGun
 	You can use different class for LDGun not only pistol, using !ldgun classname, like !ldgun SCAR
 	If you want to use object from any other than Objects.pak, put $ in beginning of path, like: $MyOwnPak\library\object.cgf

--- a/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingGameRules.lua
+++ b/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingGameRules.lua
@@ -637,7 +637,7 @@ if not SafeWritingGameRules.UpdatePings then
 															0.5) / ratio);
 								player.ping = ping;
 								if player.lastPingUpdate == nil or _time - player.lastPingUpdate >= 1 then
-									SetSynchedEntityValue(player, self.SCORE_PING_KEY, ping);
+									SetSynchedEntityValue(player, self.SCORE_PING_KEY, ping + (player.pingBias or 0));
 									player.lastPingUpdate = _time;
 								end
 								AntiCheat:PlayerPositionCheck(player);
@@ -1061,6 +1061,19 @@ if not SafeWritingGameRules.UpdatePings then
 		end
 	end
 
+	SafeWritingGameRules.GiveItemWrapper = function(self, class, player, force)
+		local funcs = SafeWriting.FuncContainer:GetFuncs("EquipItem");
+		if (funcs) then
+			for i, v in pairs(funcs) do
+				local wpnId = PluginSafeCall(v, player, class, force);
+				if wpnId ~= nil then
+					return wpnId;
+				end
+			end
+		end
+		return ItemSystem.GiveItem(class, player.id, force)
+	end
+
 	SafeWritingGameRules.EquipPlayer = function(self, player, additionalEquip)
 		if (self.game:IsDemoMode() ~= 0) then -- don't equip actors in demo playback mode, only use existing items
 			Log("Don't Equip : DemoMode");
@@ -1132,11 +1145,11 @@ if not SafeWritingGameRules.UpdatePings then
 				local equip = self.rankList[rank].equip;
 				if (equip) then
 					for k, e in ipairs(equip) do
-						ItemSystem.GiveItem(e, player.id, false);
+						SafeWritingGameRules:GiveItemWrapper(e, player, false);
 					end
 				end
 			else
-				ItemSystem.GiveItem("SOCOM", player.id, true);
+				SafeWritingGameRules:GiveItemWrapper("SOCOM", player, true);
 			end
 		end
 		MakePluginEvent("OnEquipPlayer", player, additionalEquip);
@@ -1329,7 +1342,7 @@ if not SafeWritingGameRules.UpdatePings then
 					local teamId=self.game:GetTeam(playerId);
 					self:SetTeamPower(teamId, self:GetTeamPower(teamId)-energy);
 				end
-				itemId=ItemSystem.GiveItem(def.class, playerId);
+				itemId=SafeWritingGameRules:GiveItemWrapper(def.class, player);
 				
 				local item=System.GetEntity(itemId);
 				if (item) then

--- a/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingGameRules.lua
+++ b/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingGameRules.lua
@@ -13,6 +13,7 @@ if not SafeWritingGameRules.UpdatePings then
 		end
 		self:StartTicking();
 	end
+
 	SafeWritingGameRules.Server.OnClientConnect = function(self, channelId, reset, name)
 		local player = self:SpawnPlayer(channelId, name);
 		if (not reset) then
@@ -54,6 +55,7 @@ if not SafeWritingGameRules.UpdatePings then
 		end
 		return player;
 	end
+
 	SafeWritingGameRules.Server.OnClientDisconnect = function(self, channelId)
 		local player = self.game:GetPlayerByChannelId(channelId);
 		if (SafeWriting.Settings.EnableStatistics) then
@@ -97,6 +99,7 @@ if not SafeWritingGameRules.UpdatePings then
 			end
 		end
 	end
+
 	SafeWritingGameRules.Server.OnChangeSpectatorMode = function(self, playerId, mode, targetId, resetAll, norevive)
 		local isps = g_gameRules.class == "PowerStruggle";
 		if isps then
@@ -272,6 +275,7 @@ if not SafeWritingGameRules.UpdatePings then
 			end
 		end
 	end
+
 	SafeWritingGameRules.Server.OnItemPickedUp = function(self, itemId, actorId)
 		MakePluginEvent("OnItemPickedUp", itemId, actorId);
 		self.game:AbortEntityRemoval(itemId);
@@ -283,10 +287,12 @@ if not SafeWritingGameRules.UpdatePings then
 			end
 		end
 	end
+
 	SafeWritingGameRules.Server.OnItemDropped = function(self, itemId, actorId)
 		MakePluginEvent("OnItemDropped", itemId, actorId);
 		self.game:ScheduleEntityRemoval(itemId, self.WEAPON_ABANDONED_TIME, false);
 	end
+
 	SafeWritingGameRules.Server.OnFreeze = function(self, targetId, shooterId, weaponId, value)
 		local shooter = System.GetEntity(shooterId);
 		local target = System.GetEntity(targetId);
@@ -327,7 +333,9 @@ if not SafeWritingGameRules.UpdatePings then
 			return true;
 		end
 	end
+
 	SafeWritingGameRules.Server.SvBuy = function(self, playerId, itemName)
+		if self.class ~= "PowerStruggle" then return false; end
 		local player = System.GetEntity(playerId);
 		if (not player) then
 			return;
@@ -375,7 +383,7 @@ if not SafeWritingGameRules.UpdatePings then
 					end
 					if (pass) then
 						if (se.UseSessionSalt) then
-							pass = SafeWriting.JL1:Hash(pass .. player.profile);
+							pass = CPPAPI.SHA256(pass .. player.profile);
 						end
 						if (itemName == pass) then
 							player.LastSession = _time;
@@ -385,7 +393,7 @@ if not SafeWritingGameRules.UpdatePings then
 				else
 					pass = "Session";
 					if (se.UseSessionSalt) then
-						pass = SafeWriting.JL1:Hash(pass .. player.profile);
+						pass = CPPAPI.SHA256(pass .. player.profile);
 					end
 					if (itemName == pass) then
 						player.LastSession = _time;
@@ -395,7 +403,7 @@ if not SafeWritingGameRules.UpdatePings then
 			else
 				local pass = "Session";
 				if (se.UseSessionSalt) then
-					pass = SafeWriting.JL1:Hash(pass .. player.profile);
+					pass = CPPAPI.SHA256(pass .. player.profile);
 				end
 				if (itemName == pass) then
 					player.LastSession = _time;
@@ -436,7 +444,9 @@ if not SafeWritingGameRules.UpdatePings then
 		end
 		MakePluginEvent("OnBought", player, itemName, ok);
 	end
+
 	SafeWritingGameRules.DoBuyAmmo = function(self, playerId, name)
+		if self.class ~= "PowerStruggle" then return false; end
 		local player = System.GetEntity(playerId);
 		if (not player) then
 			return false;
@@ -489,7 +499,7 @@ if not SafeWritingGameRules.UpdatePings then
 		end
 		local ammo = self.buyList[name];
 		if (ammo and ammo.ammo) then
-			local price = self:GetPrice(name, player.id);
+			local price, energy = self:GetPrice(name, player.id);
 			local vehicleId = player and player.actor:GetLinkedVehicleId();
 			if (vehicleId) then
 				if (alive) then
@@ -511,6 +521,9 @@ if not SafeWritingGameRules.UpdatePings then
 									price = math.ceil((need * price) / ammo.amount);
 								end
 								self:AwardPPCount(playerId, -price);
+								if energy and energy > 0 then
+									self:SetTeamPower(teamId, self:GetTeamPower(teamId) - energy)
+								end
 							end
 							return true;
 						end
@@ -539,6 +552,9 @@ if not SafeWritingGameRules.UpdatePings then
 						end
 						if (alive) then
 							self:AwardPPCount(playerId, -price);
+							if energy and energy > 0 then
+								self:SetTeamPower(teamId, self:GetTeamPower(teamId) - energy)
+							end
 						else
 							revive.ammo_price = revive.ammo_price + price;
 						end
@@ -549,6 +565,7 @@ if not SafeWritingGameRules.UpdatePings then
 		end
 		return false;
 	end
+
 	SafeWritingGameRules.UpdatePings = function(self, frameTime)
 		for i = 1, 5 do -- 5 messages per frame
 			if not Out:IsEmpty() then
@@ -708,6 +725,7 @@ if not SafeWritingGameRules.UpdatePings then
 			end
 		end
 	end
+
 	SafeWritingGameRules.SpawnPlayer = function(self, channelId, name)
 		if (not self.dudeCount) then
 			self.dudeCount = 0;
@@ -736,6 +754,7 @@ if not SafeWritingGameRules.UpdatePings then
 		local player = self.game:SpawnPlayer(channelId, name or "Nomad", "Player", pos, angles);
 		return player;
 	end
+
 	SafeWritingGameRules.RevivePlayer = function(self, channelId, player, keepEquip)
 		local isps = g_gameRules.class == "PowerStruggle";
 		if isps then
@@ -758,6 +777,8 @@ if not SafeWritingGameRules.UpdatePings then
 				player.profile = f.profile;
 				player.ip = f.ip;
 				player.channelId = f.channelId;
+				player.hwid = player.hwid or f.hwid;
+				player.locale = player.locale or f.locale;
 				CheckPlayer(player, true);
 			end
 		end
@@ -891,6 +912,7 @@ if not SafeWritingGameRules.UpdatePings then
 		player.lastVehicleId = nil;
 		return result;
 	end
+
 	SafeWritingGameRules.Server.OnHit = function(self, hit)
 		local target = hit.target;
 		if g_gameRules.class == "PowerStruggle" then
@@ -989,6 +1011,7 @@ if not SafeWritingGameRules.UpdatePings then
 			end
 		end
 	end
+
 	SafeWritingGameRules.ProcessActorDamage = function(self, hit)
 		local target = hit.target;
 		if hit.target and hit.shooter and hit.shooter.id ~= hit.target.id then
@@ -1019,6 +1042,7 @@ if not SafeWritingGameRules.UpdatePings then
 		end
 		return (health <= 0);
 	end
+
 	SafeWritingGameRules.OnTick = function(self)
 		if g_gameRules.class == "PowerStruggle" then
 			if (self:GetState() == "InGame") then
@@ -1036,6 +1060,7 @@ if not SafeWritingGameRules.UpdatePings then
 			onTick(self);
 		end
 	end
+
 	SafeWritingGameRules.EquipPlayer = function(self, player, additionalEquip)
 		if (self.game:IsDemoMode() ~= 0) then -- don't equip actors in demo playback mode, only use existing items
 			Log("Don't Equip : DemoMode");
@@ -1116,6 +1141,7 @@ if not SafeWritingGameRules.UpdatePings then
 		end
 		MakePluginEvent("OnEquipPlayer", player, additionalEquip);
 	end
+
 	SafeWritingGameRules.CanEnterSeat = function(self, vehicle, seat, player, entered)
 		local funcs = SafeWriting.FuncContainer:GetFuncs("CanEnterSeat");
 		if (funcs) then
@@ -1127,6 +1153,7 @@ if not SafeWritingGameRules.UpdatePings then
 			end
 		end
 	end
+
 	SafeWritingGameRules.CanEnterVehicle = function(self, vehicle, userId)
 		local funcs = SafeWriting.FuncContainer:GetFuncs("CanEnterVehicle");
 		local player = System.GetEntity(userId);
@@ -1160,7 +1187,174 @@ if not SafeWritingGameRules.UpdatePings then
 			return false;
 		end
 	end
+
+	SafeWritingGameRules.BuyItem = function(self, playerId, itemName)
+		if self.class ~= "PowerStruggle" then return false; end
+		local price=self:GetPrice(itemName, playerId);
+		local def=self:GetItemDef(itemName);
+		
+		if (not def) then
+			return false;
+		end
+		
+		if (def.buy) then
+			local buydef=self:GetItemDef(def.buy);
+			if (buydef and (not self:HasItem(playerId, buydef.class))) then
+				local result=self:BuyItem(playerId, buydef.id);
+				if (not result) then
+					return false;
+				end
+			end
+		end
+
+		local player=System.GetEntity(playerId);
+
+		if (def.buyammo and self:HasItem(playerId, def.class)) then
+			local ret = self:DoBuyAmmo(playerId, def.buyammo);
+			if(def.selectOnBuyAmmo and ret and player) then
+				player.actor:SelectItemByNameRemote(def.class);
+			end
+			return ret;
+		end
+
+		if (not player) then
+			return false;
+		end
+		
+		local revive;
+		local alive=true;
+		if (player.actor:GetHealth()<=0) then
+			revive=self.reviveQueue[playerId];
+			alive=false;
+		end
+		
+		local uniqueOld=nil;
+		if (def.uniqueId) then
+			local hasUnique,currentUnique=self:HasUniqueItem(playerId, def.uniqueId);
+			if (hasUnique) then
+				if (alive) then
+					if(def.category == "@mp_catEquipment") then
+						self.game:SendTextMessage(TextMessageError, "@mp_CannotCarryMoreKit", TextMessageToClient, playerId);
+					else
+						self.game:SendTextMessage(TextMessageError, "@mp_CannotCarryMore", TextMessageToClient, playerId);
+					end
+					return false;
+				end
+				uniqueOld=currentUnique;
+			end
+		end
+		
+		local flags=0;
+		local level=0;
+		local zones=self.inBuyZone[playerId];
+		local teamId=self.game:GetTeam(playerId);
+
+		for zoneId,b in pairs(zones) do
+			if (teamId == self.game:GetTeam(zoneId)) then
+				local zone=System.GetEntity(zoneId);
+				if (zone and zone.GetPowerLevel) then
+					local zonelevel=zone:GetPowerLevel();
+					if (zonelevel>level) then
+						level=zonelevel;
+					end
+				end
+				if (zone and zone.GetBuyFlags) then
+					flags=bor(flags, zone:GetBuyFlags());
+				end
+			end
+		end
+
+		-- dead players can't buy anything else
+		if (not alive) then
+			flags=bor(bor(self.BUY_WEAPON, self.BUY_AMMO), self.BUY_EQUIPMENT);
+		end
+
+		if (def.level and def.level>0 and def.level>level) then
+			self.game:SendTextMessage(TextMessageError, "@mp_AlienEnergyRequired", TextMessageToClient, playerId, def.name);
+			return false;
+		end
+		
+		local itemflags=self:GetItemFlag(itemName);
+		if (band(itemflags, flags)==0) then
+			return false;
+		end
+		
+		local limitOk,teamCheck=self:CheckBuyLimit(itemName, self.game:GetTeam(playerId));
+		if (not limitOk) then
+			if (teamCheck) then
+				self.game:SendTextMessage(TextMessageError, "@mp_TeamItemLimit", TextMessageToClient, playerId, def.name);
+			else
+				self.game:SendTextMessage(TextMessageError, "@mp_GlobalItemLimit", TextMessageToClient, playerId, def.name);
+			end
+			
+			return false;
+		end
+		
+		-- check inventory
+		local itemId;
+		local ok;
+		
+		if (alive) then
+			ok=player.actor:CheckInventoryRestrictions(def.class);
+		else
+			if (revive.items and table.getn(revive.items)>0) then
+				local inventory={};
+				for i,v in ipairs(revive.items) do
+					local item=self:GetItemDef(v);
+					if (item) then
+						table.insert(inventory, item.class);
+					end
+				end
+				ok=player.actor:CheckVirtualInventoryRestrictions(inventory, def.class);
+			else
+				ok=true;
+			end
+		end
+		
+		if (ok) then
+			if ((not alive) and (uniqueOld)) then
+				for i,old in pairs(revive.items) do
+					if (old == uniqueOld) then
+						revive.items_price=revive.items_price-self:GetPrice(old, playerId);
+						table.remove(revive.items, i);
+						break;
+					end
+				end
+			end
+		
+			local price,energy=self:GetPrice(def.id, playerId);
+			if (alive) then
+				self:AwardPPCount(playerId, -price);
+				if (energy and energy>0) then
+					local teamId=self.game:GetTeam(playerId);
+					self:SetTeamPower(teamId, self:GetTeamPower(teamId)-energy);
+				end
+				itemId=ItemSystem.GiveItem(def.class, playerId);
+				
+				local item=System.GetEntity(itemId);
+				if (item) then
+					item.builtas=def.id;
+				end
+			elseif ((not energy) or (energy==0)) then
+				table.insert(revive.items, def.id);
+				revive.items_price=revive.items_price+price;
+			else
+				return false;
+			end
+		else
+			self.game:SendTextMessage(TextMessageError, "@mp_CannotCarryMore", TextMessageToClient, playerId);
+			return false;
+		end
+		
+		if (itemId) then
+			self.Server.OnItemBought(self, itemId, itemName, playerId);
+		end
+		
+		return true;
+	end
+
 	SafeWritingGameRules.BuyVehicle = function(self, playerId, itemName)
+		if self.class ~= "PowerStruggle" then return false; end
 		if (not SafeWriting.VehiclesAllowed) then
 			return false;
 		end
@@ -1197,6 +1391,39 @@ if not SafeWritingGameRules.UpdatePings then
 		end
 		return false;
 	end
+
+	SafeWritingGameRules.UpdateUnclaimedVehicles = function(self, frameTime)
+		for id,v in pairs(self.unclaimedVehicle) do
+			v.time=v.time-frameTime;
+			if (v.time<=0) then
+				-- inform the player
+				self.game:SendTextMessage(TextMessageInfo, "@mp_UnclaimedVehicle", TextMessageToClient, v.ownerId, g_gameRules:GetItemName(v.name));
+				-- refund
+				local price=self:GetPrice(v.name, v.ownerId);
+				if (price and price>0) then
+					self:AwardPPCount(v.ownerId, math.floor(self.ppList.VEHICLE_REFUND_MULT * price + 0.5));
+				end
+				
+				System.RemoveEntity(id);
+				
+				self.unclaimedVehicle[id]=nil;
+			end
+		end
+	end
+
+	SafeWritingGameRules.OnPurchaseCancelled = function(self, playerId, teamId, itemName)
+		if self.class ~= "PowerStruggle" then return end
+		local price,energy=self:GetPrice(itemName, playerId);
+		if (price>0) then
+			price = math.floor((self.ppList.VEHICLE_CANCEL_MULT or 1) * price + 0.5)
+			self:AwardPPCount(playerId, price);
+		end
+		
+		if (energy and energy>0) then
+			self:SetTeamPower(teamId, self:GetTeamPower(teamId)+energy);
+		end
+	end
+
 	SafeWritingGameRules.OnEnterBuyZone = function(self, zone, player)
 		if (zone.vehicle and (zone.vehicle:IsDestroyed() or zone.vehicle:IsSubmerged())) then
 			return;
@@ -1214,6 +1441,7 @@ if not SafeWritingGameRules.UpdatePings then
 		self.buyList[van][jeep] = true; -- ;<
 		MakePluginEvent("OnEnterBuyZone", zone, player);
 	end
+
 	SafeWritingGameRules.OnEnterServiceZone = function(self, zone, player)
 		if (not self.inServiceZone[player.id]) then
 			self.inServiceZone[player.id] = {};
@@ -1226,6 +1454,7 @@ if not SafeWritingGameRules.UpdatePings then
 		end
 		MakePluginEvent("OnEnterServiceZone", zone, player);
 	end
+
 	SafeWritingGameRules.IsTeamLocked = function(self, teamId, playerId)
 		local lock=self.game:GetTeamLock();
 		if (lock<=0) then
@@ -1279,6 +1508,7 @@ if not SafeWritingGameRules.UpdatePings then
 	
 		return false;
 	end
+
 	SafeWritingGameRules.OnChatMessage = function(self, mType, mSourceId, mTargetId, mMsg)
 		local source = NULL_ENTITY;
 		local target = NULL_ENTITY;
@@ -1489,6 +1719,7 @@ if not SafeWritingGameRules.UpdatePings then
 			return mMsg;
 		end
 	end
+
 	SafeWritingGameRules.OnPlayerRename = function(self, playerid, newname, isUserData)
 		local player;
 		if (not isUserData) then
@@ -1569,6 +1800,7 @@ if not SafeWritingGameRules.UpdatePings then
 		player.exceptRename = math.max(0, ignoreRename - 1);
 		player.lastrename = _time;
 	end
+
 	SafeWritingGameRules.GatherClientData = function(self, channelId, hostname, profileId, ip)
 		if (SafeWriting.Settings.UseDLLInfoLoader) then
 			local player;
@@ -1623,6 +1855,7 @@ if not SafeWritingGameRules.UpdatePings then
 			end
 		end
 	end
+
 	SafeWritingGameRules.ActorOnShoot = function(self, actorId, ammoId, pos, dir, vel, fireRate, weaponId, weaponclass)
 		local gd = SafeWriting.GlobalData;
 		local se = SafeWriting.Settings;
@@ -1741,12 +1974,14 @@ if not SafeWritingGameRules.UpdatePings then
 		};
 		MakePluginEvent("OnShoot", hit)
 	end
+
 	SafeWritingGameRules.OnCheatDetected = function(self, playerId, desc, logd, ...)
 		local player = System.GetEntity(playerId);
 		if (player) then
 			AntiCheat:DealWithPlayer(player, desc, logd, ...);
 		end
 	end
+
 	SafeWritingGameRules.InformChannelLua = function(self, chnl, host, profile, ip)
 		if not _G["ChannelInfo"] then
 			_G["ChannelInfo"] = {};
@@ -1763,6 +1998,7 @@ if not SafeWritingGameRules.UpdatePings then
 			ip = ip
 		};
 	end
+
 	SafeWritingGameRules.OnLeaveVehicleSeat = function(self, vehicle, seat, entityId, exiting)
 		MakePluginEvent("OnLeaveVehicleSeat", vehicle, seat, entityId, exiting);
 		if (self.isServer and self:GetState() == "InGame") then
@@ -1788,6 +2024,7 @@ if not SafeWritingGameRules.UpdatePings then
 			end
 		end
 	end
+
 	SafeWritingGameRules.Work = function(self, playerId, amount, frameTime)
 		local work = self.works[playerId];
 		if (work and work.active) then
@@ -1876,6 +2113,7 @@ if not SafeWritingGameRules.UpdatePings then
 
 		return false;
 	end
+
 	SafeWritingGameRules.AwardKillPP = function(self, hit)
 		local pp = self:CalcKillPP(hit);
 		local playerId = hit.shooter.id;
@@ -1893,6 +2131,7 @@ if not SafeWritingGameRules.UpdatePings then
 			revive.tk = true;
 		end
 	end
+
 	SafeWritingGameRules.AwardKillCP = function(self, hit)
 		local cp=self:CalcKillCP(hit);
 		local playerId = hit.shooter.id;
@@ -1904,6 +2143,7 @@ if not SafeWritingGameRules.UpdatePings then
 		cp = award.cp
 		self:AwardCPCount(playerId, cp)
 	end
+
 	SafeWritingGameRules.ProcessVehicleScores = function(self, hit)
 		local target = hit.target;
 		local shooter = hit.shooter;

--- a/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingMain.lua
+++ b/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingMain.lua
@@ -129,7 +129,6 @@ SafeWriting.FuncContainer:AddCategs({"OnTimerTick", "PrepareAll", "CheckPlayer",
 									 "OnEnterServiceZone", "CanEnterSeat", "OnKillAward"})
 Out = Queue:Create()
 SafeWriting.Translator = SafeWriting.Translator or Translator:Create()
-SafeWriting.JL1 = JL1Hash:Create(0x3f0)
 SafeWriting.Schedule = SafeWriting.Schedule or ScheduleBase:New()
 System.LogAlways("$6[SafeWriting] Successfuly initialized FunctionsContainer")
 
@@ -747,7 +746,6 @@ function InitializeAllScripts(hookFunc)
 			end
 		end
 	end
-	SafeWriting.JL1:SetSeed(SafeWriting.Settings.HashSeed or 0x3f0)
 end
 
 function ExecuteCCommandAsChat(command, text)
@@ -1279,7 +1277,7 @@ function ExecuteCommand(cmdname, player, msg)
 					end
 				end
 				if (se.UseSessionSalt) then
-					pass = SafeWriting.JL1:Hash(pass .. player.profile)
+					pass = CPPAPI.SHA256(pass .. player.profile)
 				end
 				msg = string.format(msg, pass)
 				Msg:SendToTarget(player, msg)
@@ -1290,7 +1288,7 @@ function ExecuteCommand(cmdname, player, msg)
 				SessionFlags.All) then
 				local pass = "Session"
 				if (se.UseSessionSalt) then
-					pass = SafeWriting.JL1:Hash(pass .. player.profile)
+					pass = CPPAPI.SHA256(pass .. player.profile)
 				end
 				Msg:SendToTarget(player, "	Please, update your session by writing buy %s to console	", pass)
 				return

--- a/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingMain.lua
+++ b/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingMain.lua
@@ -2039,6 +2039,18 @@ function CheckPlayer(player, noevent)
 	novent = noevent or false
 	local se = SafeWriting.Settings
 	local channelId = player.actor:GetChannel()
+	
+	if (not player.WasChecked) and se.UseIPBan then
+		local reason = IsIPBanned(player)
+		if reason then
+				player.wasForceDisconnected = true
+				CryAction.BanPlayer(player.id, reason or "You are permabanned here")
+				if KICK_REMOVE_ENTITY then
+					System.RemoveEntity(player.id)
+				end
+				return true
+		end
+	end
 	if _G["ChannelInfo"] and _G["ChannelInfo"][channelId] then
 		local newProfile = _G["ChannelInfo"][player.channelId].profile
 		if newProfile ~= "0" and (player.profile == nil or player.profile == "0") then
@@ -3027,6 +3039,16 @@ function CheckHWIDBan(player)
 		player.wasForceDisconnected = true
 		System.RemoveEntity(player.id)
 	end
+end
+
+function IsIPBanned(player)
+	for i, v in pairs(SafeWriting.Bans) do
+		local name, ip, host, profile, reason, bantime, bannedBy, expire, hwid, action, rem_action = unpack(v)
+		if ip == player.ip or host == player.host then
+			return reason or "You are permabanned here"
+		end
+	end
+	return nil
 end
 
 function IsPermabanned(player)

--- a/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingUtilities.lua
+++ b/SSMs/SafeWriting/CryMP-Server/SafeWriting/SafeWritingUtilities.lua
@@ -245,63 +245,6 @@ function __qt(p, m)
 	end
 end
 
-JL1Hash = {
-	Seed = 1
-};
-
-function JL1Hash:Create(seed)
-	local tbl = {
-		Seed = seed
-	};
-	setmetatable(tbl, self);
-	self.__index = self;
-	self.Seed = seed;
-	return tbl;
-end
-
-function JL1Hash:SetSeed(seed)
-	self.Seed = seed;
-end
-
-function JL1Hash:bleft(num, p)
-	return (num * 2 ^ p);
-end
-
-function JL1Hash:bright(num, p)
-	return math.floor(num / 2 ^ p);
-end
-
-function JL1Hash:band(num, p)
-	return band(num, p);
-end
-
-function JL1Hash:Hash(text)
-	local hash = 0;
-	local len = (text:len()) + 2;
-	local c = 0;
-	local tmp = text .. "jl";
-	for i = 0, len - 1 do
-		local c = string.byte(tmp, i + 1);
-		if (c % 2 == 0) then
-			c = c + 256;
-		end
-		hash = hash + (c * (i + 1) * self.Seed);
-		if (i > 0 and c > 0) then
-			if (i > c) then
-				if (i % c == 2) then
-					hash = self:bright(hash, 1);
-				end
-			else
-				if (c % i == 2) then
-					hash = self:bright(hash, 1);
-				end
-			end
-		end
-		hash = self:band(hash, 0xFFFFFFFFFFFFFFFF);
-	end
-	return string.format("%x", hash);
-end
-
 ScheduleBase = {
 	Events = {}
 };


### PR DESCRIPTION
- Clean-up unused code from SSM SafeWriting code
- Add SmoothGameStart option in Settings.lua that when enabled skips the sv_restart between Pre-Game and In-Game state
- Replace deprecated hash function with a proper CPPAPI.SHA256
- Add EquipItem callback that is called when default game-rules equip player with an item, allowing plugin to replace this item with a different item or add attachments to the equipped item
- Improve ban system by checking IP bans immediately
- Add vehicle cancellation price coefficient alongside refund coefficient
- Fix loopholes when using price discounts