### PR TITLE
Add item skins

### DIFF
--- a/Code/CryGame/Items/Item.cpp
+++ b/Code/CryGame/Items/Item.cpp
@@ -410,6 +410,24 @@ void CItem::Update(SEntityUpdateContext& ctx, int slot)
 		m_bPostPostSerialize = false;
 	}
 
+	int SKIN_KEY = m_stats.viewmode == eIVM_FirstPerson ? 1001 : 1002;
+	CSynchedStorage* pSSS = g_pGame->GetSynchedStorage();
+	if (pSSS) {
+		IEntity* pEntity = GetEntity();
+		std::string skin;
+		if (pEntity && pSSS->GetEntityValue(pEntity->GetId(), SKIN_KEY, skin) && skin != m_skin) {
+			m_skin = skin;
+			IMaterialManager* pMM = gEnv->p3DEngine->GetMaterialManager();
+			IMaterial *pMaterial = pMM->LoadMaterial(skin.c_str());
+			if (pMaterial) {
+				pEntity->SetMaterial(pMaterial);
+				CryLog("Loaded item skin '%s' onto entityId %u", skin.c_str(), pEntity->GetId());
+			} else {
+				CryLogWarning("Couldn't find material '%s'", skin.c_str());
+			}
+		}
+	}
+
 	if (m_frozen || IsDestroyed())
 		return;
 

--- a/Code/CryGame/Items/Item.h
+++ b/Code/CryGame/Items/Item.h
@@ -1446,6 +1446,7 @@ public:
 	}
 
 	bool m_fpMasterHidden = false;
+	std::string m_skin;
 };
 
 #endif //__ITEM_H__


### PR DESCRIPTION
You know what Crysis really needs? You guessed it right: weapon skins!

We already use entity keys 1001 and 1002 for player models, so why not extend it further to weapon skins?

1001: First person skin
1002: Third person skin

Since release was postponed anyway, I think we could include this in it as well


https://github.com/user-attachments/assets/ac7e2054-9d1e-4bc4-a538-53d33184d591



Example usage

```lua
function GetWeapon(player)
	local wpnId = player.inventory:GetCurrentItemId();
	if wpnId then
		local wpn = System.GetEntity(wpnId);
		return wpn;
	end
end

local wpn = GetWeapon(player)
if wpn and wpn.class == "FY71" then
	SetSynchedEntityValue(wpn, 1001, "Objects/Weapons/Asian/FY71/fy71_khaki.mtl")
	SetSynchedEntityValue(wpn, 1002, "Objects/Weapons/Asian/FY71/fy71_khaki_tp.mtl")
end
```