### PR TITLE
Reload textures, shaders and nanosuit material after server PAK changes

### DIFF
--- a/Code/CryGame/Actors/Player/NanoSuit.cpp
+++ b/Code/CryGame/Actors/Player/NanoSuit.cpp
@@ -97,6 +97,28 @@ static void PrecacheMaterials(bool bCacheAsian)
 	}
 }
 
+void CNanoSuit::ResetCachedMaterials()
+{
+	for (int i = 0; i < NANOMODE_LAST; ++i)
+	{
+		SAFE_RELEASE(g_USNanoMats[i].body);
+		SAFE_RELEASE(g_USNanoMats[i].helmet);
+		SAFE_RELEASE(g_USNanoMats[i].arms);
+
+		g_USNanoMats[i].body = nullptr;
+		g_USNanoMats[i].helmet = nullptr;
+		g_USNanoMats[i].arms = nullptr;
+
+		SAFE_RELEASE(g_AsianNanoMats[i].body);
+		SAFE_RELEASE(g_AsianNanoMats[i].helmet);
+		SAFE_RELEASE(g_AsianNanoMats[i].arms);
+
+		g_AsianNanoMats[i].body = nullptr;
+		g_AsianNanoMats[i].helmet = nullptr;
+		g_AsianNanoMats[i].arms = nullptr;
+	}
+}
+
 CNanoSuit::SNanoMaterial* CNanoSuit::GetNanoMaterial(ENanoMode mode, bool bAsian)
 {
 	const int nIndex = mode;

--- a/Code/CryGame/Actors/Player/NanoSuit.cpp
+++ b/Code/CryGame/Actors/Player/NanoSuit.cpp
@@ -105,17 +105,9 @@ void CNanoSuit::ResetCachedMaterials()
 		SAFE_RELEASE(g_USNanoMats[i].helmet);
 		SAFE_RELEASE(g_USNanoMats[i].arms);
 
-		g_USNanoMats[i].body = nullptr;
-		g_USNanoMats[i].helmet = nullptr;
-		g_USNanoMats[i].arms = nullptr;
-
 		SAFE_RELEASE(g_AsianNanoMats[i].body);
 		SAFE_RELEASE(g_AsianNanoMats[i].helmet);
 		SAFE_RELEASE(g_AsianNanoMats[i].arms);
-
-		g_AsianNanoMats[i].body = nullptr;
-		g_AsianNanoMats[i].helmet = nullptr;
-		g_AsianNanoMats[i].arms = nullptr;
 	}
 }
 

--- a/Code/CryGame/Actors/Player/NanoSuit.cpp
+++ b/Code/CryGame/Actors/Player/NanoSuit.cpp
@@ -58,7 +58,7 @@ static void PrecacheMaterials(bool bCacheAsian)
 		g_USNanoMats[NANOMODE_DEFENSE_HIT_REACTION].body = matMan->LoadMaterial("objects/characters/human/us/nanosuit/nanosuit_us_defense.mtl");
 		g_USNanoMats[NANOMODE_DEFENSE_HIT_REACTION].helmet = matMan->LoadMaterial("objects/characters/human/us/nanosuit/nanosuit_us_helmet_defense.mtl");
 		g_USNanoMats[NANOMODE_DEFENSE_HIT_REACTION].arms = matMan->LoadMaterial("objects/weapons/arms_global/arms_nanosuit_us_defense.mtl");
-		// strategically leak it
+		// Keep materials referenced while cached
 		for (int i = 0; i < NANOMODE_LAST; ++i)
 		{
 			g_USNanoMats[i].body->AddRef();
@@ -87,7 +87,7 @@ static void PrecacheMaterials(bool bCacheAsian)
 		g_AsianNanoMats[NANOMODE_DEFENSE_HIT_REACTION].body = matMan->LoadMaterial("objects/characters/human/asian/nanosuit/nanosuit_asian_defense.mtl");
 		g_AsianNanoMats[NANOMODE_DEFENSE_HIT_REACTION].helmet = matMan->LoadMaterial("objects/characters/human/asian/nanosuit/nanosuit_asian_helmet_defense.mtl");
 		g_AsianNanoMats[NANOMODE_DEFENSE_HIT_REACTION].arms = matMan->LoadMaterial("objects/weapons/arms_global/arms_nanosuit_asian_defense.mtl");
-		// strategically leak it
+		// Keep materials referenced while cached
 		for (int i = 0; i < NANOMODE_LAST; ++i)
 		{
 			g_AsianNanoMats[i].body->AddRef();

--- a/Code/CryGame/Actors/Player/NanoSuit.h
+++ b/Code/CryGame/Actors/Player/NanoSuit.h
@@ -196,6 +196,7 @@ public:
 
 	static SNanoMaterial* GetNanoMaterial(ENanoMode mode, bool bAsian=false);
 	static bool AssignNanoMaterialToEntity(IEntity* pEntity, SNanoMaterial* pNanoMaterial);
+	static void ResetCachedMaterials();
 
 	CNanoSuit();
 	~CNanoSuit();

--- a/Code/CryMP/Client/Client.cpp
+++ b/Code/CryMP/Client/Client.cpp
@@ -549,6 +549,11 @@ void Client::OnActionEvent(const SActionEvent & event)
 			ReloadLocalizationLua();
 			break;
 		}
+		case eAE_inGame:
+		{
+			m_pServerPAK->OnInGame();
+			break;
+		}
 		case eAE_channelCreated:
 		case eAE_channelDestroyed:
 		case eAE_connectFailed:
@@ -558,7 +563,6 @@ void Client::OnActionEvent(const SActionEvent & event)
 		case eAE_resetProgress:
 		case eAE_preSaveGame:
 		case eAE_postSaveGame:
-		case eAE_inGame:
 		case eAE_serverName:
 		case eAE_serverIp:
 		case eAE_earlyPreUpdate:

--- a/Code/CryMP/Common/ServerPAK.cpp
+++ b/Code/CryMP/Common/ServerPAK.cpp
@@ -66,18 +66,20 @@ bool ServerPAK::Unload()
 
 void ServerPAK::OnLoadingStart(ILevelInfo* pLevel)
 {
-	if (m_reloadResources)
-	{
-		CNanoSuit::ResetCachedMaterials();
+	if (!m_reloadResources)
+		return;
 
-		if (ICVar* pReloadShaders = gEnv->pConsole->GetCVar("r_ReloadShaders"))
-		{
-			if (pReloadShaders->GetIVal() == 0)
-			{
-				CryLogAlways("$3[CryMP] [ServerPAK] Reloading shaders");
-				pReloadShaders->Set(1);
-			}
-		}
+	CNanoSuit::ResetCachedMaterials();
+
+	if (ICVar* pReloadShaders = gEnv->pConsole->GetCVar("r_ReloadShaders"))
+	{
+		const int flags = pReloadShaders->GetFlags();
+
+		pReloadShaders->SetFlags((flags & ~VF_CHEAT) | VF_NOT_NET_SYNCED);
+		pReloadShaders->Set(1);
+		pReloadShaders->SetFlags(flags);
+
+		CryLogAlways("$3[CryMP] [ServerPAK] Reloading shaders");
 	}
 }
 

--- a/Code/CryMP/Common/ServerPAK.cpp
+++ b/Code/CryMP/Common/ServerPAK.cpp
@@ -1,6 +1,7 @@
 #include "CryCommon/CrySystem/ISystem.h"
 #include "CryCommon/CryEntitySystem/IEntitySystem.h"
 #include "CryCommon/CryScriptSystem/IScriptSystem.h"
+#include "CryCommon/CrySystem/IConsole.h"
 #include "CryCommon/CryNetwork/INetwork.h"
 #include "CryCommon/CryAction/IVehicleSystem.h"
 #include "CryCommon/CryAction/IItemSystem.h"
@@ -8,7 +9,9 @@
 #include "CryGame/Game.h"
 #include "CryGame/Items/ItemSharedParams.h"
 #include "CryGame/Items/Weapons/WeaponSystem.h"
+#include "CryGame/Actors/Player/NanoSuit.h" 
 #include "CrySystem/CryPak.h"
+
 
 #include "ServerPAK.h"
 #include "Utilities.h"
@@ -51,6 +54,7 @@ bool ServerPAK::Unload()
 	{
 		CryLogAlways("$3[CryMP] [ServerPAK] Unloaded $6%s", m_path.c_str());
 		m_path.clear();
+		m_reloadResources = true;
 	}
 	else
 	{
@@ -62,6 +66,29 @@ bool ServerPAK::Unload()
 
 void ServerPAK::OnLoadingStart(ILevelInfo* pLevel)
 {
+	if (m_reloadResources)
+	{
+		CNanoSuit::ResetCachedMaterials();
+
+		if (ICVar* pReloadShaders = gEnv->pConsole->GetCVar("r_ReloadShaders"))
+		{
+			if (pReloadShaders->GetIVal() == 0)
+			{
+				CryLogAlways("$3[CryMP] [ServerPAK] Reloading shaders");
+				pReloadShaders->Set(1);
+			}
+		}
+	}
+}
+
+void ServerPAK::OnInGame()
+{
+	if (m_reloadResources)
+	{
+		CryLogAlways("$3[CryMP] [ServerPAK] Reloading textures");
+		gEnv->pRenderer->EF_ReloadTextures();
+		m_reloadResources = false;
+	}
 }
 
 void ServerPAK::OnConnect()

--- a/Code/CryMP/Common/ServerPAK.h
+++ b/Code/CryMP/Common/ServerPAK.h
@@ -7,6 +7,7 @@ struct ILevelInfo;
 class ServerPAK
 {
 	std::string m_path;
+	bool m_reloadResources = false;
 
 public:
 	ServerPAK();
@@ -16,6 +17,7 @@ public:
 	bool Unload();
 	void OnLoadingStart(ILevelInfo* pLevel);
 	void OnConnect();
+	void OnInGame();
 	void OnDisconnect(int reason, const char* message);
 	void ResetSubSystems();
 };


### PR DESCRIPTION
So that custom skins don't persist after a server change.

Include shader reload so that it's active for any server.