### PR TITLE
Fix reloading server PAK textures

### DIFF
--- a/Code/CryMP/Client/Client.cpp
+++ b/Code/CryMP/Client/Client.cpp
@@ -527,6 +527,7 @@ void Client::OnActionEvent(const SActionEvent & event)
 			const char *message = event.m_description;
 
 			m_pScriptCallbacks->OnDisconnect(reason, message);
+			m_pEngineCache->OnDisconnect();
 			m_pServerPAK->OnDisconnect(reason, message);
 			m_pDrawTools->OnDisconnect(reason, message);
 			m_pServerConnector->OnDisconnect();
@@ -549,11 +550,6 @@ void Client::OnActionEvent(const SActionEvent & event)
 			ReloadLocalizationLua();
 			break;
 		}
-		case eAE_inGame:
-		{
-			m_pServerPAK->OnInGame();
-			break;
-		}
 		case eAE_channelCreated:
 		case eAE_channelDestroyed:
 		case eAE_connectFailed:
@@ -563,6 +559,7 @@ void Client::OnActionEvent(const SActionEvent & event)
 		case eAE_resetProgress:
 		case eAE_preSaveGame:
 		case eAE_postSaveGame:
+		case eAE_inGame:
 		case eAE_serverName:
 		case eAE_serverIp:
 		case eAE_earlyPreUpdate:

--- a/Code/CryMP/Client/EngineCache.cpp
+++ b/Code/CryMP/Client/EngineCache.cpp
@@ -46,111 +46,80 @@ EngineCache::~EngineCache()
 int EngineCache::ScanFolder(const char* folderName)
 {
 	int counter = 0;
-	const string folder = folderName;
-	string search = folder;
-	search += "/*.*";
+	std::string wildcard = folderName;
+	wildcard += "/*.*";
 
-	for (auto& entry : CryFind(search.c_str()))
+	for (auto& entry : CryFind(wildcard.c_str()))
 	{
+		std::string entryPath = folderName;
+		entryPath += '/';
+		entryPath += entry.name;
+
 		if (entry.IsDirectory())
 		{
-			string subName = folder + "/" + entry.name;
-			if (m_recursing)
-			{
-				int c = ScanFolder(subName.c_str());
-				counter += c;
-			}
-			else
-			{
-				m_recursing = true;
-				int c = ScanFolder(subName.c_str());
-				counter += c;
-				m_recursing = false;
-			}
-			continue;
+			counter += ScanFolder(entryPath.c_str());
 		}
-
-		const char* ext = CryPath::GetExt(entry.name);
-
-		//supported file ext
-		if (_stricmp(ext, "cdf") && _stricmp(ext, "cgf") && _stricmp(ext, "cga") && _stricmp(ext, "chr"))
-			continue;
-
-		//skip folders
-		if (folder == "Objects/Characters/Human/asian/infantry/camp" || folder == "Objects/Characters/Human/asian/infantry/jungle" ||
-			folder == "Objects/Characters/Human/asian/infantry/elite")
-			continue;
-
-		if (string(entry.name) == "nanosuit_us_parachute.cdf" || string(entry.name) == "nanosuit_us_with_weapon.cdf" ||
-			string(entry.name) == "rifleman_light.chr" || string(entry.name) == "rifleman_heavy.chr")
-			continue;
-
-		string cdfFile = folder + string("/") + string(entry.name);
-
-		if (Cache(folder, cdfFile))
-			++counter;
+		else
+		{
+			counter += Cache(entryPath.c_str());
+		}
 	}
 
 	return counter;
 }
 
-bool EngineCache::Cache(string folder, string file)
+bool EngineCache::Cache(const char* file)
 {
-	float color[] = { 1.0, 1.0, 1.0, 1.0 };
-	//CryLogAlways("Caching %s... (%s)", file.c_str(), folder.c_str());
+	const char* ext = CryPath::GetExt(file);
 
-	const char* ext = CryPath::GetExt(file.c_str());
 	if (!_stricmp(ext, "cdf") || !_stricmp(ext, "chr") || !_stricmp(ext, "cga"))
 	{
-		ICharacterInstance* pChar = gEnv->pCharacterManager->CreateInstance(file.c_str());
+		ICharacterInstance* pChar = gEnv->pCharacterManager->CreateInstance(file);
 		if (pChar && pChar->GetFilePath())
 		{
 			pChar->AddRef();
+			m_cachedCharacterInstances.emplace_back(pChar);
 			return true;
 		}
 	}
 	else if (!_stricmp(ext, "cgf"))
 	{
-		IStatObj* pStatObj = gEnv->p3DEngine->LoadStatObj(file.c_str());
+		IStatObj* pStatObj = gEnv->p3DEngine->LoadStatObj(file);
 		if (pStatObj && pStatObj->GetFilePath())
 		{
 			pStatObj->AddRef();
+			m_cachedStatObjs.emplace_back(pStatObj);
 			return true;
 		}
 	}
 	else if (!_stricmp(ext, "mtl"))
 	{
-		IMaterial* pMat = gEnv->p3DEngine->GetMaterialManager()->LoadMaterial(file.c_str());
+		IMaterial* pMat = gEnv->p3DEngine->GetMaterialManager()->LoadMaterial(file);
 		if (pMat)
 		{
 			pMat->AddRef();
+			m_cachedMaterials.emplace_back(pMat);
 		}
 	}
+
 	return false;
 }
 
 void EngineCache::OnLoadingStart(ILevelInfo* pLevel)
 {
-	m_isCaching = false;
+	m_isCached = false;
 }
 
 void EngineCache::OnLoadingProgress(ILevelInfo* pLevel, int progressAmount)
 {
-	if (pLevel && !m_isCaching && cl_engineCacheLevel)
+	if (m_isCached)
 	{
-		m_isCaching = true;
-
-		Start();
-	}
-}
-
-void EngineCache::Start()
-{
-	if (!cl_engineCacheLevel || cl_engineCacheLevel <= static_cast<int>(m_cacheStatus))
 		return;
+	}
+
+	m_isCached = true;
 
 	int counter = 0;
-
 	std::vector<std::string> folders = {};
 
 	if (cl_engineCacheLevel == MINIMUM)
@@ -189,13 +158,19 @@ void EngineCache::Start()
 
 	for (const std::string& folder : folders)
 	{
-		int c = ScanFolder(folder.c_str());
-		counter += c;
+		counter += ScanFolder(folder.c_str());
 	}
 
-	m_cacheStatus = static_cast<ECacheLevel>(cl_engineCacheLevel);
-
-	if (counter)
+	if (counter > 0)
+	{
 		CryLogAlways("$3[CryMP] Successfully cached %d objects", counter);
+	}
 }
 
+void EngineCache::OnDisconnect()
+{
+	// flush the cache
+	m_cachedCharacterInstances.clear();
+	m_cachedMaterials.clear();
+	m_cachedStatObjs.clear();
+}

--- a/Code/CryMP/Client/EngineCache.h
+++ b/Code/CryMP/Client/EngineCache.h
@@ -1,13 +1,15 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+
+struct ICharacterInstance;
 struct ILevelInfo;
+struct IMaterial;
+struct IStatObj;
 
 class EngineCache
 {
-	bool m_recursing = false;
-	bool m_isCaching = false;
-	int cl_engineCacheLevel = 0;
-	
 	enum ECacheLevel
 	{
 		DISABLED,
@@ -17,20 +19,31 @@ class EngineCache
 		LUDICROUS
 	};
 
-	ECacheLevel m_cacheStatus = ECacheLevel::DISABLED;
+	template<class T>
+	struct Releaser
+	{
+		void operator()(T* p) const { p->Release(); }
+	};
+
+	using SmartCharacterInstance = std::unique_ptr<ICharacterInstance, Releaser<ICharacterInstance>>;
+	using SmartMaterial = std::unique_ptr<IMaterial, Releaser<IMaterial>>;
+	using SmartStatObj = std::unique_ptr<IStatObj, Releaser<IStatObj>>;
+
+	std::vector<SmartCharacterInstance> m_cachedCharacterInstances;
+	std::vector<SmartMaterial> m_cachedMaterials;
+	std::vector<SmartStatObj> m_cachedStatObjs;
+
+	bool m_isCached = false;
+	int cl_engineCacheLevel = 0;
+
+	int ScanFolder(const char* folderName);
+	bool Cache(const char* file);
 
 public:
 	EngineCache();
 	~EngineCache();
 
-	int ScanFolder(const char* folderName);
-	bool Cache(string folder, string file);
 	void OnLoadingStart(ILevelInfo* pLevel);
 	void OnLoadingProgress(ILevelInfo* pLevel, int progressAmount);
-	void Start();
-	ECacheLevel GetStatus()
-	{
-		return m_cacheStatus;
-	}
-
+	void OnDisconnect();
 };

--- a/Code/CryMP/Client/ServerConnector.cpp
+++ b/Code/CryMP/Client/ServerConnector.cpp
@@ -304,8 +304,6 @@ void ServerConnector::Reconnect()
 			m_server.name.empty() ? m_server.CreateEndpointString().c_str() : m_server.name.c_str());
 	}
 
-	gClient->GetServerPAK()->OnConnect();
-
 	IConsole *pConsole = gEnv->pConsole;
 
 	pConsole->GetCVar("cl_serveraddr")->Set(m_server.GetPreferredHost().c_str());

--- a/Code/CryMP/Common/ServerPAK.cpp
+++ b/Code/CryMP/Common/ServerPAK.cpp
@@ -12,7 +12,6 @@
 #include "CryGame/Actors/Player/NanoSuit.h" 
 #include "CrySystem/CryPak.h"
 
-
 #include "ServerPAK.h"
 #include "Utilities.h"
 
@@ -24,7 +23,7 @@ ServerPAK::~ServerPAK()
 {
 }
 
-bool ServerPAK::Load(const std::string & path)
+bool ServerPAK::Load(const std::string& path)
 {
 	Unload();
 
@@ -54,7 +53,6 @@ bool ServerPAK::Unload()
 	{
 		CryLogAlways("$3[CryMP] [ServerPAK] Unloaded $6%s", m_path.c_str());
 		m_path.clear();
-		m_reloadResources = true;
 	}
 	else
 	{
@@ -66,41 +64,29 @@ bool ServerPAK::Unload()
 
 void ServerPAK::OnLoadingStart(ILevelInfo* pLevel)
 {
-	if (!m_reloadResources)
-		return;
-
 	CNanoSuit::ResetCachedMaterials();
 
 	if (ICVar* pReloadShaders = gEnv->pConsole->GetCVar("r_ReloadShaders"))
 	{
-		const int flags = pReloadShaders->GetFlags();
-
-		pReloadShaders->SetFlags((flags & ~VF_CHEAT) | VF_NOT_NET_SYNCED);
-		pReloadShaders->Set(1);
-		pReloadShaders->SetFlags(flags);
-
 		CryLogAlways("$3[CryMP] [ServerPAK] Reloading shaders");
-	}
-}
 
-void ServerPAK::OnInGame()
-{
-	if (m_reloadResources)
-	{
-		CryLogAlways("$3[CryMP] [ServerPAK] Reloading textures");
-		gEnv->pRenderer->EF_ReloadTextures();
-		m_reloadResources = false;
+		const int flags = pReloadShaders->GetFlags();
+		pReloadShaders->SetFlags((flags & ~VF_CHEAT) | VF_NOT_NET_SYNCED);
+		pReloadShaders->Set(0x10); // FRO_FORCERELOAD
+		pReloadShaders->SetFlags(flags);
 	}
-}
-
-void ServerPAK::OnConnect()
-{
-	Unload();
 }
 
 void ServerPAK::OnDisconnect(int reason, const char* message)
 {
 	gEnv->pScriptSystem->ResetTimers();
+
+	IGameFramework* pGameFrameWork = gEnv->pGame->GetIGameFramework();
+	IItemSystem* pItemSystem = pGameFrameWork->GetIItemSystem();
+	pItemSystem->ClearGeometryCache();
+	pItemSystem->ClearSoundCache();
+
+	Unload();
 }
 
 void ServerPAK::ResetSubSystems()

--- a/Code/CryMP/Common/ServerPAK.h
+++ b/Code/CryMP/Common/ServerPAK.h
@@ -7,17 +7,14 @@ struct ILevelInfo;
 class ServerPAK
 {
 	std::string m_path;
-	bool m_reloadResources = false;
 
 public:
 	ServerPAK();
 	~ServerPAK();
 
-	bool Load(const std::string & path);
+	bool Load(const std::string& path);
 	bool Unload();
 	void OnLoadingStart(ILevelInfo* pLevel);
-	void OnConnect();
-	void OnInGame();
 	void OnDisconnect(int reason, const char* message);
 	void ResetSubSystems();
 };


### PR DESCRIPTION
Instead of `IRenderer::EF_ReloadTextures`, which sometimes crashes DX9 renderer, simply flush the cached objects in ItemSystem and EngineCache after disconnect.

Also clean up the EngineCache implementation a bit.

And instead of unloading server PAK before connect, unload it right after disconnect. This fixes server PAK unloading in singleplayer.